### PR TITLE
feat/python2to3

### DIFF
--- a/plugins/cpuutilize.py
+++ b/plugins/cpuutilize.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 

--- a/plugins/harddiskreadwritetime.py
+++ b/plugins/harddiskreadwritetime.py
@@ -17,7 +17,7 @@ client = db.connect(DBNAME,user='root',passwd=123456)
 
 # load BPF program
 b = BPF(text="""
-#inc3lude <uapi/linux/ptrace.h>
+#include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 struct val_t {
     u32 pid;

--- a/plugins/harddiskreadwritetime.py
+++ b/plugins/harddiskreadwritetime.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-from __future__ import print_function
+#!/usr/bin/python3
 from bcc import BPF
 import re, signal, sys
 from time import sleep
@@ -18,7 +17,7 @@ client = db.connect(DBNAME,user='root',passwd=123456)
 
 # load BPF program
 b = BPF(text="""
-#include <uapi/linux/ptrace.h>
+#inc3lude <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 struct val_t {
     u32 pid;

--- a/plugins/irq.py
+++ b/plugins/irq.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 

--- a/plugins/memusage.py
+++ b/plugins/memusage.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 
 from bcc import BPF
 import os
 import sys
 from time import sleep
-import thread
+import _thread
 
 # for influxdb
 from influxdb import InfluxDBClient
@@ -21,28 +21,31 @@ USER = cfg.getProperty("influxdb.user")
 PASSWORD = cfg.getProperty("influxdb.password")
 
 
-client = db.connect(DBNAME,user=USER,passwd=PASSWORD)
+client = db.connect(DBNAME, user=USER, passwd=PASSWORD)
 
-title = ['DMA','DMA32','Normal']
+title = ['DMA', 'DMA32', 'Normal']
 #print("%-9s%-9s%-9s" % (title[0], title[1], title[2]))
 
 # data structure from template
-class lmp_data(object):
-    def __init__(self,a,b,c,d,e):
-		self.time = a
-		self.glob = b
-		self.dma = c
-		self.dma32 = d
-		self.normal = e
 
-data_struct = {"measurement":'memusage',
-			   "time":[],
-			   "tags":['glob'],
-			   "fields":['dma','dma32','normal']}
+
+class lmp_data(object):
+    def __init__(self, a, b, c, d, e):
+        self.time = a
+        self.glob = b
+        self.dma = c
+        self.dma32 = d
+        self.normal = e
+
+
+data_struct = {"measurement": 'memusage',
+               "time": [],
+               "tags": ['glob'],
+               "fields": ['dma', 'dma32', 'normal']}
 
 
 def load_BPF(thread_name, delay):
-    b = BPF(text = '''
+    b = BPF(text='''
             #include <uapi/linux/ptrace.h>
 
             int kprobe_wakeup_kswapd(struct pt_regs *ctx)
@@ -54,63 +57,66 @@ def load_BPF(thread_name, delay):
             }
             ''')
 
-
     b.trace_print()
 
-def zone_info(thread_name, delay):
-	path = "/proc/zoneinfo"
-	title = ['DMA','DMA32','Normal']
-        data = ['0','0','0']
-	while 1:
-		try:
-			sleep(1)
-		except keyboardInterrupt:
-			exit()
-		f = open( path )
-		line = f.readline()
-		pages_free = '0'
-		managed = '0'
-		count = 0
-                i = 0
-                k = 0
-                #print(title)
-		while line:
-			if ':' in line:
-				line = line.replace(':', '')
-			strline = line.split()
-			# if strline[3] == 'DMA':
-			if strline[0] == 'pages':
-			    pages_free = strline[2]
-			    count = count + 1
-			if strline[0] == 'managed':
-			    managed = strline[1]
-			    count = count + 1
-			if pages_free != '0' and managed != '0' and count ==2:
-			    result = float(pages_free)/float(managed)
-                            if i == 0:
-                                data[i] = "%.4f"%result
-                            elif i==1:
-                                data[i] ="%.4f"% result
-                            elif i == 2:
-                                data[i] ="%.4f"% result
-                            i = i+1
-			    count = 0
 
-			line = f.readline()
-                #print(data)
-                #print("%-9s%-9s%-9s" % (data[0], data[1], data[2]))
-                test_data = lmp_data(datetime.now().isoformat(),'glob', data[0], data[1], data[2])
-            	write2db(data_struct, test_data, client)
-		#print('------------')
-		f.close()
+def zone_info(thread_name, delay):
+    path = "/proc/zoneinfo"
+    title = ['DMA', 'DMA32', 'Normal']
+    data = ['0', '0', '0']
+    while 1:
+        try:
+            sleep(1)
+        except keyboardInterrupt:
+            exit()
+        f = open(path)
+        line = f.readline()
+        pages_free = '0'
+        managed = '0'
+        count = 0
+        i = 0
+        k = 0
+        # print(title)
+        while line:
+            if ':' in line:
+                line = line.replace(':', '')
+            strline = line.split()
+            # if strline[3] == 'DMA':
+            if strline[0] == 'pages':
+                pages_free = strline[2]
+                count = count + 1
+            if strline[0] == 'managed':
+                managed = strline[1]
+                count = count + 1
+            if pages_free != '0' and managed != '0' and count == 2:
+                result = float(pages_free)/float(managed)
+                if i == 0:
+                    data[i] = "%.4f" % result
+                elif i == 1:
+                    data[i] = "%.4f" % result
+                elif i == 2:
+                    data[i] = "%.4f" % result
+                i = i+1
+                count = 0
+
+            line = f.readline()
+        # print(data)
+        # print("%-9s%-9s%-9s" % (data[0], data[1], data[2]))
+        test_data = lmp_data(datetime.now().isoformat(),
+                             'glob', data[0], data[1], data[2])
+        write2db(data_struct, test_data, client)
+        # print('------------')
+        f.close()
+
+
 try:
-    thread.start_new_thread(load_BPF, ("BPF progream", 0))
-    thread.start_new_thread(zone_info, ("zoneinfo", 10))
+    _thread.start_new_thread(load_BPF, ("BPF progream", 0))
+    _thread.start_new_thread(zone_info, ("zoneinfo", 10))
 except:
-    print"Error:unable to start thread"
+    print("Error:unable to start thread")
 
 while 1:
-	try:
-		pass
-	except KeyboardInterrupt:
-		exit()
+    try:
+        pass
+    except KeyboardInterrupt:
+        exit()

--- a/plugins/netlatency.py
+++ b/plugins/netlatency.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-from __future__ import print_function
+#!/usr/bin/python3
 from bcc import BPF
 from socket import inet_ntop, ntohs, AF_INET, AF_INET6
 from struct import pack

--- a/plugins/picknext.py
+++ b/plugins/picknext.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 

--- a/plugins/taskswitch.py
+++ b/plugins/taskswitch.py
@@ -1,6 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
-from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 

--- a/plugins/vfsstat.py
+++ b/plugins/vfsstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # @lint-avoid-python-3-compatibility-imports
 #
 # vfsstat.py   Count some VFS calls.
@@ -14,7 +14,6 @@
 # 14-Aug-2015   Brendan Gregg   Created this.
 # 15-Sep-2020   Chenyu Zhao     Edited
 
-from __future__ import print_function
 from bcc import BPF
 from ctypes import c_int
 from time import sleep, strftime

--- a/plugins/waitingqueuelength.py
+++ b/plugins/waitingqueuelength.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 # @lint-avoid-python-3-compatibility-imports
 #
@@ -21,7 +21,6 @@
 # 12-Dec-2016   Brendan Gregg   Created this.
 # 17-Sep-2020   Chenyu Zhao     Edited
 
-from __future__ import print_function
 from bcc import BPF, PerfType, PerfSWConfig
 from time import sleep, strftime
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
做了三件事
1. 将所有脚本的解释器换为python3，删去了`from __future__ import print_function`
2.`memusage.py `中`thead`在python3中已废弃，改为`_thead`
3 `memusage.py`中使用的是`tab`而不是四个空格，根据PEP8格式化为四个空格