### PR TITLE
style: go fmt, go vet, fix unreachable code path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 0.1
-.PHONY: all clean modules
+.PHONY: all clean modules lint
 
 PREFIX    ?= /usr/libexec/lmp
 COLLECTDIR = $(PREFIX)/collector
@@ -22,7 +22,7 @@ clean:
 
 install:
 	@echo "BEGIN INSTALL LMP"
-	mkdir -p /etc/influxdb/influxdb.conf 
+	mkdir -p /etc/influxdb/influxdb.conf
 	mkdir -p /var/lib/influxdb/data
 	mkdir -p /var/lib/influxdb/meta
 	mkdir -p /var/lib/influxdb/wal influxdb
@@ -36,3 +36,8 @@ install:
 # 	install -m 644 test/prometheus/* $(PRODIR)
 # 	install -m 640 test/grafana/* $(DASHDIR)
 
+lint:
+	go fmt ./...
+	go vet ./...
+	gofmt -e -l .
+	# golint `go list ./... | grep -v /vendor/`

--- a/controllers/bccplugins.go
+++ b/controllers/bccplugins.go
@@ -3,9 +3,8 @@ package controllers
 import (
 	"fmt"
 
-	"lmp/logic"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
 )
 
 func UpLoadFiles(c *gin.Context) {

--- a/controllers/collect.go
+++ b/controllers/collect.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	_ "time"
 
-	"lmp/logic"
-	"lmp/models"
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/controllers/tj.go
+++ b/controllers/tj.go
@@ -1,9 +1,8 @@
 package controllers
 
 import (
-	"lmp/logic"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
 	"go.uber.org/zap"
 )
 

--- a/dao/influxdb/data.go
+++ b/dao/influxdb/data.go
@@ -3,9 +3,8 @@ package influxdb
 import (
 	"fmt"
 
-	"lmp/settings"
-
 	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/settings"
 )
 
 // Gets a specified number of data

--- a/dao/influxdb/influxdb.go
+++ b/dao/influxdb/influxdb.go
@@ -3,9 +3,8 @@ package influxdb
 import (
 	"fmt"
 
-	"lmp/settings"
-
 	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module lmp
+module github.com/linuxkerneltravel/lmp
 
 go 1.12
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"github.com/natefinch/lumberjack"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/logic/bccplugins.go
+++ b/logic/bccplugins.go
@@ -3,10 +3,9 @@ package logic
 import (
 	"mime/multipart"
 
-	"lmp/models"
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/logic/collect.go
+++ b/logic/collect.go
@@ -8,8 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"lmp/models"
-
+	"github.com/linuxkerneltravel/lmp/models"
 	"go.uber.org/zap"
 )
 

--- a/logic/tj.go
+++ b/logic/tj.go
@@ -1,9 +1,8 @@
 package logic
 
 import (
-	"lmp/dao/influxdb"
-
-	"github.com/influxdata/influxdb1-client/v2"
+	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/dao/influxdb"
 	"go.uber.org/zap"
 )
 

--- a/main.go
+++ b/main.go
@@ -10,12 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"lmp/logger"
-	"lmp/models"
-	"lmp/routes"
-	"lmp/settings"
-
 	"github.com/facebookgo/pidfile"
+	"github.com/linuxkerneltravel/lmp/logger"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/routes"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/models/bccplugins.go
+++ b/models/bccplugins.go
@@ -8,8 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"lmp/settings"
-
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 
@@ -98,8 +97,9 @@ func (b *BpfScan) Run() {
 }
 
 func (b *BpfScan) Watch() {
-	ticker := time.NewTicker(time.Second * 3) // 运行时长
 	go func() {
+		ticker := time.NewTicker(time.Second * 3) // 运行时长
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -110,7 +110,6 @@ func (b *BpfScan) Watch() {
 				}
 			}
 		}
-		ticker.Stop()
 	}()
 }
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,14 +1,13 @@
 package routes
 
 import (
+	"fmt"
 	"net/http"
 
-	"lmp/controllers"
-	"lmp/logger"
-
-	"fmt"
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/controllers"
+	"github.com/linuxkerneltravel/lmp/logger"
 )
 
 func SetupRouter(mode string) *gin.Engine {


### PR DESCRIPTION
This commit fixes various style problems:
1. change go module name to `github.com/linuxkerneltravel/lmp`
2. run `go fmt`, `go vet`, `golint` against the code base
3. fix unreachable code figured out by `go vet`
4. add `lint` target to Makefile