### PR TITLE
添加一个内存指标

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 0.1
-.PHONY: all clean modules
+.PHONY: all clean modules lint
 
 PREFIX    ?= /usr/libexec/lmp
 COLLECTDIR = $(PREFIX)/collector
@@ -22,7 +22,7 @@ clean:
 
 install:
 	@echo "BEGIN INSTALL LMP"
-	mkdir -p /etc/influxdb/influxdb.conf 
+	mkdir -p /etc/influxdb/influxdb.conf
 	mkdir -p /var/lib/influxdb/data
 	mkdir -p /var/lib/influxdb/meta
 	mkdir -p /var/lib/influxdb/wal influxdb
@@ -36,3 +36,8 @@ install:
 # 	install -m 644 test/prometheus/* $(PRODIR)
 # 	install -m 640 test/grafana/* $(DASHDIR)
 
+lint:
+	go fmt ./...
+	go vet ./...
+	gofmt -e -l .
+	# golint `go list ./... | grep -v /vendor/`

--- a/controllers/bccplugins.go
+++ b/controllers/bccplugins.go
@@ -3,9 +3,8 @@ package controllers
 import (
 	"fmt"
 
-	"lmp/logic"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
 )
 
 func UpLoadFiles(c *gin.Context) {

--- a/controllers/collect.go
+++ b/controllers/collect.go
@@ -27,7 +27,12 @@ func Collect(c *gin.Context) {
 
 func fillFrontMessage(c *gin.Context) models.ConfigMessage {
 	var m models.ConfigMessage
-
+	if v, ok := c.GetPostForm("swap_pagefault"); ok && v == "true" {
+                m.Swap_pagefault = true
+                m.BpfFilePath = append(m.BpfFilePath, settings.Conf.PluginConfig.Path+"swap_pagefault.py")
+        } else {
+                m.Swap_pagefault = false
+        }
 	if v, ok := c.GetPostForm("cpuutilize"); ok && v == "true" {
 		m.Cpuutilize = true
 		m.BpfFilePath = append(m.BpfFilePath, settings.Conf.PluginConfig.Path+"cpuutilize.py")

--- a/controllers/collect.go
+++ b/controllers/collect.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	_ "time"
 
-	"lmp/logic"
-	"lmp/models"
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/controllers/tj.go
+++ b/controllers/tj.go
@@ -1,9 +1,8 @@
 package controllers
 
 import (
-	"lmp/logic"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/logic"
 	"go.uber.org/zap"
 )
 

--- a/controllers/tj.go
+++ b/controllers/tj.go
@@ -5,6 +5,16 @@ import (
 	"github.com/linuxkerneltravel/lmp/logic"
 	"go.uber.org/zap"
 )
+func QuerySwap_pagefault(c *gin.Context) {
+        res, err := logic.DoQuerySwap_pagefault()
+        if err != nil {
+                zap.L().Error("ERROR in QuerySwap_pagefault():", zap.Error(err))
+                ResponseError(c, CodeServerBusy)
+                return
+        }
+
+        ResponseSuccess(c, res)
+}
 
 func QueryIRQ(c *gin.Context) {
 	res, err := logic.DoQueryIRQ()

--- a/dao/influxdb/data.go
+++ b/dao/influxdb/data.go
@@ -3,9 +3,8 @@ package influxdb
 import (
 	"fmt"
 
-	"lmp/settings"
-
 	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/settings"
 )
 
 // Gets a specified number of data

--- a/dao/influxdb/influxdb.go
+++ b/dao/influxdb/influxdb.go
@@ -3,9 +3,8 @@ package influxdb
 import (
 	"fmt"
 
-	"lmp/settings"
-
 	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module lmp
+module github.com/linuxkerneltravel/lmp
 
 go 1.12
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,9 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"github.com/natefinch/lumberjack"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/logic/bccplugins.go
+++ b/logic/bccplugins.go
@@ -3,10 +3,9 @@ package logic
 import (
 	"mime/multipart"
 
-	"lmp/models"
-	"lmp/settings"
-
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/logic/collect.go
+++ b/logic/collect.go
@@ -8,8 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"lmp/models"
-
+	"github.com/linuxkerneltravel/lmp/models"
 	"go.uber.org/zap"
 )
 

--- a/logic/tj.go
+++ b/logic/tj.go
@@ -1,9 +1,8 @@
 package logic
 
 import (
-	"lmp/dao/influxdb"
-
-	"github.com/influxdata/influxdb1-client/v2"
+	client "github.com/influxdata/influxdb1-client/v2"
+	"github.com/linuxkerneltravel/lmp/dao/influxdb"
 	"go.uber.org/zap"
 )
 

--- a/logic/tj.go
+++ b/logic/tj.go
@@ -16,6 +16,15 @@ func DoQueryIRQ() (res []client.Result, err error) {
 	return
 }
 
+func DoQuerySwap_pagefault() (res []client.Result, err error) {
+        res, err = influxdb.QueryDB(`select last("duration") from "swap_pagefault"`)
+        if err != nil {
+                zap.L().Error("ERROR in Doswap_pagefault():", zap.Error(err))
+                return nil, err
+        }
+        return
+}
+
 func DoQueryCpuUtilize() (res []client.Result, err error) {
 	res, err = influxdb.QueryDB(`select last("perce") from "cpuutilize"`)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,12 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"lmp/logger"
-	"lmp/models"
-	"lmp/routes"
-	"lmp/settings"
-
 	"github.com/facebookgo/pidfile"
+	"github.com/linuxkerneltravel/lmp/logger"
+	"github.com/linuxkerneltravel/lmp/models"
+	"github.com/linuxkerneltravel/lmp/routes"
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 

--- a/models/bccplugins.go
+++ b/models/bccplugins.go
@@ -8,8 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"lmp/settings"
-
+	"github.com/linuxkerneltravel/lmp/settings"
 	"go.uber.org/zap"
 )
 
@@ -98,8 +97,9 @@ func (b *BpfScan) Run() {
 }
 
 func (b *BpfScan) Watch() {
-	ticker := time.NewTicker(time.Second * 3) // 运行时长
 	go func() {
+		ticker := time.NewTicker(time.Second * 3) // 运行时长
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
@@ -110,7 +110,6 @@ func (b *BpfScan) Watch() {
 				}
 			}
 		}
-		ticker.Stop()
 	}()
 }
 

--- a/models/pluginparam.go
+++ b/models/pluginparam.go
@@ -9,6 +9,7 @@ type ConfigMessage struct {
 	Runqlen      bool `json:"runqlen"`
 	Vfsstat      bool `json:"vfsstat"`
 	Dcache       bool `json:"dcache"`
+	Swap_pagefault bool `json:"swap_pagefault"`
 
 	// Store the config above to the 'BpfFilePath'
 	BpfFilePath []string `json:"bpfFilePath"`

--- a/plugins/swap_pagefault.py
+++ b/plugins/swap_pagefault.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+
+# for influxdb
+from influxdb import InfluxDBClient
+import lmp_influxdb as db
+from db_modules import write2db
+
+from datetime import datetime
+
+
+DBNAME = 'lmp'
+
+client = db.connect(DBNAME,user='root',passwd=123456)
+
+b = BPF(text = '''
+        #include <uapi/linux/ptrace.h>
+        #include <linux/ktime.h>
+        
+        BPF_HASH(timer, u32, ktime_t);
+      
+        int kprobe__do_swap_page(struct pt_regs *ctx)
+        {
+               
+                u32 pid = bpf_get_current_pid_tgid();
+             
+                ktime_t start = bpf_ktime_get_ns();
+                timer.update(&pid, &start);
+
+                return 0;
+        }
+   
+        int kretprobe__do_swap_page(struct pt_regs *ctx)
+        {
+             
+                ktime_t end = bpf_ktime_get_ns();
+                int ret = PT_REGS_RC(ctx);
+                
+                u32 pid = bpf_get_current_pid_tgid();
+                
+                ktime_t delta;
+                
+                ktime_t *tsp = timer.lookup(&pid);
+                if ((ret >= 0) && (tsp != NULL))
+                        delta = end - *tsp;
+         
+                if (delta >= 10000000) {/* 大于10ms的进行输出 */
+                        bpf_trace_printk("%lld\\n", delta);
+                }
+
+                //bpf_trace_printk("%lld\\n", delta);
+
+                return 0;
+        }
+        ''')
+
+
+# data structure from template
+class lmp_data(object):
+    def __init__(self,a,b,c):
+            self.time = a
+            self.glob = b
+            self.duration = c
+
+data_struct = {"measurement":'swap_pagefault',
+               "time":[],
+               "tags":['glob'],
+               "fields":['duration']}
+
+
+
+timer = b.get_table("timer")
+
+#print("%-6s%-6s%-6s%-6s" % ("CPU", "PID", "TGID", "TIME(us)"))
+while (1):
+    try:
+        sleep(1)
+        for k, v in timer.items():
+            #print("%-6d%-6d%-6d%-6d" % (k.cpu, k.pid, k.tgid, v.value / 1000))
+            test_data = lmp_data(datetime.now().isoformat(),'glob', v.value/1000)
+            write2db(data_struct, test_data, client)
+            #print("This is success")
+        timer.clear()
+    except KeyboardInterrupt:
+        exit()
+
+
+
+

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,14 +1,13 @@
 package routes
 
 import (
+	"fmt"
 	"net/http"
 
-	"lmp/controllers"
-	"lmp/logger"
-
-	"fmt"
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
+	"github.com/linuxkerneltravel/lmp/controllers"
+	"github.com/linuxkerneltravel/lmp/logger"
 )
 
 func SetupRouter(mode string) *gin.Engine {

--- a/static/index.html
+++ b/static/index.html
@@ -46,6 +46,7 @@
             <input type="checkbox" name="runqlen" value="true">runqlen&nbsp;&nbsp;&nbsp;
             <input type="checkbox" name="vfsstat" value="true">vfsstat&nbsp;&nbsp;&nbsp;
             <input type="checkbox" name="dcache" value="true">dcache&nbsp;
+            <input type="checkbox" name="swap_pagefault" value="true">swap_pagefault&nbsp;
             <label for="other"></label>
             <input type="text" name="collecttime" value="-1">
             <br>

--- a/test/grafana-JSON/lmp.json
+++ b/test/grafana-JSON/lmp.json
@@ -577,6 +577,129 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"duration\" FROM \"swap_pagefault\" ",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "swap_pagefault",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
         "x": 12,
         "y": 17
       },


### PR DESCRIPTION
梁鹏，张纪庆
指标名称：do_swap_page

do_swap_page是一种缺页中断类型。

指标含义：当pte所对应的page不在内存中，且pte对应的内容不为0时，表示此时pte的内容所对应的页面在swap空间中，缺页异常时会通过do_swap_page()函数来分配页面。

指标提取思路：meminfo中的SwapCached字段记录了在交换缓存上的内容容量。所谓交换缓存是指，在换入某个内存页之后，物理磁盘上的交换空间依然保留同样的数据，这样的内存页会记录在"交换缓存"的列表上。 这样的好处在于，当需要再次换出记录在交换缓存中的的内存页时，可以直接使用交换分区中保存的内容，而无需将内存再次写入交换空间。当该交换空间上的其他数据被换出，或是换入内存中的数据被改写，则交换缓存上的记录会被清空。

我们可以通过监控他来查看内存的这种缺页异常他的处理延时。当项目利用go并发同时运行多个协程时就可以监控到，越多延时也越高。
