### PR TITLE
feat: migrate python2 to python3

### DIFF
--- a/logic/collect.go
+++ b/logic/collect.go
@@ -35,7 +35,7 @@ func execute(filepath string, collectTime int, exitChan chan bool) {
 		}
 	}()
 
-	cmd := exec.Command("sudo", "python", filepath)
+	cmd := exec.Command("sudo", "python3", filepath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout, err := cmd.StdoutPipe()

--- a/plugins/cpuutilize.py
+++ b/plugins/cpuutilize.py
@@ -5,6 +5,7 @@ from bcc import BPF
 from time import sleep, strftime
 
 # for influxdb
+from const import DatabaseType
 from init_db import influx_client
 from db_modules import write2db
 
@@ -109,7 +110,7 @@ while (1):
             #print("%-6d%-16d%-16d%-6.4f%%" % (k.value, v.total, v.idle, 1.0 *(v.total - v.idle) / v.total * 100))
             test_data = lmp_data(
                 datetime.now().isoformat(), 'glob', cpu[k.value])
-            write2db(data_struct, test_data, influx_client, 1)
+            write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
         dist.clear()
 
     except KeyboardInterrupt:

--- a/plugins/irq.py
+++ b/plugins/irq.py
@@ -94,7 +94,7 @@ while (1):
         for k, v in exitt.items():
             #print("%-6d%-6d%-6d%-6d" % (k.cpu, k.pid, k.tgid, v.value / 1000))
             test_data = lmp_data(datetime.now().isoformat(),'glob', k.cpu, k.pid, v.value/1000)
-            write2db(data_struct, test_data, influx_client, 1)
+            write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
         exitt.clear()
     except KeyboardInterrupt:
         exit()

--- a/plugins/memusage.py
+++ b/plugins/memusage.py
@@ -5,14 +5,14 @@ from bcc import BPF
 import os
 import sys
 from time import sleep
-import thread
+import _thread
 
 # for influxdb
 from init_db import influx_client
 from db_modules import write2db
 
 from datetime import datetime
-
+from const import DatabaseType
 
 
 title = ['DMA', 'DMA32', 'Normal']
@@ -59,7 +59,7 @@ def zone_info(thread_name, delay):
     while 1:
         try:
             sleep(1)
-        except keyboardInterrupt:
+        except KeyboardInterrupt:
             exit()
         f = open(path)
         line = f.readline()
@@ -93,19 +93,19 @@ def zone_info(thread_name, delay):
 
             line = f.readline()
         # print(data)
-        #print("%-9s%-9s%-9s" % (data[0], data[1], data[2]))
+        print("%-9s%-9s%-9s" % (data[0], data[1], data[2]))
         test_data = lmp_data(datetime.now().isoformat(),
                              'glob', data[0], data[1], data[2])
-        write2db(data_struct, test_data, influx_client, 1)
+        write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
         # print('------------')
         f.close()
 
 
 try:
-    thread.start_new_thread(load_BPF, ("BPF progream", 0))
-    thread.start_new_thread(zone_info, ("zoneinfo", 10))
+    _thread.start_new_thread(load_BPF, ("BPF progream", 0))
+    _thread.start_new_thread(zone_info, ("zoneinfo", 10))
 except:
-    print"Error:unable to start thread"
+    print("Error:unable to start thread")
 
 while 1:
     try:

--- a/plugins/netlatency.py
+++ b/plugins/netlatency.py
@@ -6,6 +6,7 @@ from struct import pack
 import argparse
 
 # for influxdb
+from const import DatabaseType
 from init_db import influx_client
 from db_modules import write2db
 
@@ -159,7 +160,7 @@ def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
     if event.task.decode('utf-8', 'replace') != 'influxd' and event.task.decode('utf-8', 'replace') != 'docker-proxy':
         test_data = lmp_data('glob', 'ipv6', event.task.decode('utf-8', 'replace'), event.pid, event.srtt)
-        write2db(data_struct, test_data, influx_client, 1)
+        write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
         print("%-6d %-12.12s %-2d %-20s > %-20s %d" % (
         event.pid, event.task.decode('utf-8', 'replace'), event.ip,
         "%s:%d" % (inet_ntop(AF_INET6, event.saddr), event.sport),

--- a/plugins/picknext.py
+++ b/plugins/picknext.py
@@ -95,7 +95,7 @@ while (1):
             #print("%-6d%-6d%-6d%-6d" % (k.cpu, k.pid, k.tgid, v.value))
             #test_data = lmp_data('glob', k.cpu, k.pid, v.value)
             test_data = lmp_data(datetime.now().isoformat(),'glob', k.cpu, k.pid, v.value)
-            write2db(data_struct, test_data, influx_client,1)
+            write2db(data_struct, test_data, influx_client,DatabaseType.INFLUXDB.value)
         dist.clear()
     except KeyboardInterrupt:
         exit()

--- a/plugins/taskswitch.py
+++ b/plugins/taskswitch.py
@@ -5,8 +5,10 @@ from bcc import BPF
 from time import sleep, strftime
 
 # for influxdb
+
 from init_db import influx_client
 from db_modules import write2db
+from const import DatabaseType
 
 from datetime import datetime
 
@@ -98,7 +100,7 @@ while (1):
         for k, v in dist.items():
             #print("%-6d%-6d%-6d%-6d" % (k.cpu, k.pid, k.tgid, v.value))
             test_data = lmp_data(datetime.now().isoformat(),'glob', k.cpu, k.pid, v.value)
-            write2db(data_struct, test_data, influx_client, 1)
+            write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
         dist.items()
     except KeyboardInterrupt:
         exit()

--- a/plugins/vfsstat.py
+++ b/plugins/vfsstat.py
@@ -20,6 +20,7 @@ from ctypes import c_int
 from time import sleep, strftime
 from sys import argv
 
+from const import DatabaseType
 from init_db import influx_client
 from db_modules import write2db
 
@@ -119,6 +120,6 @@ while (1):
             times=0
     # print(vfs_list[1],vfs_list[2],vfs_list[3],vfs_list[4],vfs_list[5])
     data = test_data('glob', vfs_list[1],vfs_list[2],vfs_list[3],vfs_list[4],vfs_list[5])
-    write2db(data_struct, data, influx_client, 1)
+    write2db(data_struct, data, influx_client, DatabaseType.INFLUXDB.value)
 
     b["stats"].clear()

--- a/plugins/waitingqueuelength.py
+++ b/plugins/waitingqueuelength.py
@@ -27,6 +27,7 @@ from time import sleep, strftime
 from tempfile import NamedTemporaryFile
 from os import open, close, dup, unlink, O_WRONLY
 # for influxdb
+from const import DatabaseType
 from init_db import influx_client
 from db_modules import write2db
 
@@ -57,7 +58,7 @@ def print_event(cpu, data, size):
     global start
     event = b["result"].event(data)
     test_data = lmp_data('glob', event.len)
-    write2db(data_struct, test_data, influx_client, 1)
+    write2db(data_struct, test_data, influx_client, DatabaseType.INFLUXDB.value)
     # print(event.len)
     # if start == 0:
     #         start = event.ts


### PR DESCRIPTION
1.将memusage.py 语法改为python3 语法
2.引入Enum (>python3.4 ),引入之后 python2 无法再使用
3.修改collect.go 将执行`python` 修改为 执行 `python3`