### PR TITLE
Fix the problem that MySQL connection is closed prematurely.

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ func doBeforeJob(ctx *cli.Context) error {
 		fmt.Println("Init mysql failed, err:", err)
 		return err
 	}
-	defer mysql.Close()
 
 	/*
 		if err := influxdb.Init(settings.Conf.InfluxdbConfig); err != nil {
@@ -123,6 +122,11 @@ func main() {
 
 	app.Before = doBeforeJob
 	app.Action = runlmp
+
+	defer func() {
+		// close mysql connection
+		mysql.Close()
+	}()
 
 	if err := app.Run(os.Args); err != nil {
 		fmt.Printf("%s\n", err)


### PR DESCRIPTION
使用匿名函数将关闭MySQL连接操作放到main函数中，修复了MySQL连接提前关闭的问题。