### PR TITLE
add magic number/remove timeout control

### DIFF
--- a/eBPF_Visualization/eBPF_server/service/ebpfplugins/ebpfplugins.go
+++ b/eBPF_Visualization/eBPF_server/service/ebpfplugins/ebpfplugins.go
@@ -13,6 +13,11 @@ import (
 
 type EbpfpluginsService struct{}
 
+const (
+	outputBufferCapacity = 2
+	errorBufferCapacity  = 1
+)
+
 //@author: [helight](https://github.com/hellight)
 //@function: CreateEbpfPlugins
 //@description: 创建插件
@@ -92,11 +97,11 @@ func (ebpf *EbpfpluginsService) LoadEbpfPlugins(e request.PluginInfo) (err error
 
 	// 2.加载执行
 	var wg sync.WaitGroup
-	outputChannel := make(chan int, 2)  // alter name; magic number
-	errorChannel := make(chan error, 1) // alter name
+	outputChannel := make(chan bool, outputBufferCapacity)
+	errorChannel := make(chan error, errorBufferCapacity)
 	wg.Add(1)
 	go func() {
-		runSinglePlugin(e, 1500, &outputChannel, &errorChannel)
+		runSinglePlugin(e, &outputChannel, &errorChannel)
 	}()
 	go func() {
 		select {


### PR DESCRIPTION
有些ebpf程序是瀑发式的输出，可能很长时间都没有输出，但并不代表程序是不健康的，因此删除此处的的超时控制，考虑用其他方式判断ebpf程序运行状态是否健康。