### PR TITLE
[sidecar] extract and use PIDs under root PID namespace

### DIFF
--- a/eBPF_Supermarket/sidecar/bpf/README.md
+++ b/eBPF_Supermarket/sidecar/bpf/README.md
@@ -27,6 +27,7 @@ To develop BPF program in Go, here are some best practices hints. Maybe they are
 
 1. Keep your event struct *aligned in 8 byte*. Compiler always do some unknowable things when we write not aligned code. For some time, the compiler of C and the compiler of Go organize your struct differently. And, when you read binary data from C to Go, they will come out and make trouble. So, keep your data structure aligned to avoid it.
 2. Use `/*FILTER*/` as placeholder for inserting filter code. That can make sure your code can work even if you don't provide filter code.
+3. In [iovisor/bcc@ffff0ed](https://github.com/iovisor/bcc/commit/ffff0edc00ad249cffbf44d855b15020cc968536), `bcc_func_load`'s signature was changed. However, [gobpf](https://github.com/iovisor/gobpf) still lacks of maintenance on this. So, we should change the library as [this PR](https://github.com/iovisor/gobpf/pull/311). As a workaround, we extracted this as a [new library](https://github.com/ESWZY/gobpf/tree/0.24.0), and just need use `replace` directive `replace github.com/iovisor/gobpf => github.com/ESWZY/gobpf v0.2.1-0.20220720201619-9eb793319a76` in `go.mod` file (after `go get github.com/ESWZY/gobpf@0.24.0`).
 
 ## See Also
 

--- a/eBPF_Supermarket/sidecar/bpf/podnet/podnet.go
+++ b/eBPF_Supermarket/sidecar/bpf/podnet/podnet.go
@@ -228,16 +228,7 @@ func Probe(pidList []int, reverse bool, podIp string, ch chan<- Event) {
 
 	source = string(sourceContent[:])
 	sourceBpf := source
-
-	if tools.IsInMinikubeMode() {
-		nsPidFilter, err := bpf.GetFilterByParentProcessPidNamespace(tools.MinikubePid, pidList, reverse)
-		if err != nil {
-			panic(err)
-		}
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", nsPidFilter, 1)
-	} else {
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
-	}
+	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
 
 	if ipFilter != "" {
 		sourceBpf = strings.Replace(sourceBpf, ipFilter, ipRep, 1)

--- a/eBPF_Supermarket/sidecar/bpf/tcpaccept/tcpaccept.go
+++ b/eBPF_Supermarket/sidecar/bpf/tcpaccept/tcpaccept.go
@@ -232,15 +232,7 @@ func Probe(pidList []int, portList []int, protocolList []string, ch chan<- Event
 	familyFg := bpf.FamilyFilterGenerator{List: protocolList}
 
 	sourceBpf := source
-	if tools.IsInMinikubeMode() {
-		nsPidFilter, err := bpf.GetFilterByParentProcessPidNamespace(tools.MinikubePid, pidList, false)
-		if err != nil {
-			panic(err)
-		}
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", nsPidFilter, 1)
-	} else {
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
-	}
+	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PORT*/", portFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_FAMILY*/", familyFg.Generate(), 1)
 

--- a/eBPF_Supermarket/sidecar/bpf/tcpclose/tcpclose.go
+++ b/eBPF_Supermarket/sidecar/bpf/tcpclose/tcpclose.go
@@ -418,15 +418,7 @@ func Probe(pidList []int, portList []int, protocolList []string, ch chan<- Event
 		sourceBpf += sourceKprobe
 	}
 
-	if tools.IsInMinikubeMode() {
-		nsPidFilter, err := bpf.GetFilterByParentProcessPidNamespace(tools.MinikubePid, pidList, false)
-		if err != nil {
-			panic(err)
-		}
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", nsPidFilter, 1)
-	} else {
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
-	}
+	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_LPORT*/", lportFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_DPORT*/", dportFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_FAMILY*/", familyFg.Generate(), 1)

--- a/eBPF_Supermarket/sidecar/bpf/tcpconnect/tcpconnect.go
+++ b/eBPF_Supermarket/sidecar/bpf/tcpconnect/tcpconnect.go
@@ -215,15 +215,7 @@ func Probe(pidList []int, portList []int, protocolList []string, ch chan<- Event
 	familyFg := bpf.FamilyFilterGenerator{List: protocolList}
 
 	sourceBpf := source
-	if tools.IsInMinikubeMode() {
-		nsPidFilter, err := bpf.GetFilterByParentProcessPidNamespace(tools.MinikubePid, pidList, false)
-		if err != nil {
-			panic(err)
-		}
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", nsPidFilter, 1)
-	} else {
-		sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
-	}
+	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PID*/", pidFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_PORT*/", portFg.Generate(), 1)
 	sourceBpf = strings.Replace(sourceBpf, "/*FILTER_FAMILY*/", familyFg.Generate(), 1)
 

--- a/eBPF_Supermarket/sidecar/main.go
+++ b/eBPF_Supermarket/sidecar/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	var sidecarPid []int
 	var servicePid []int
+	var portList = []int{15006, 9080, 80, 8000}
 
 	for i := 0; i < len(sidecarProcesses); i++ {
 		sidecarPid = append(sidecarPid, int(sidecarProcesses[i].Pid))
@@ -92,14 +93,16 @@ func main() {
 	pidList = append(pidList, sidecarPid...)
 	pidList = append(pidList, servicePid...)
 
-	targetPod, err := tools.LocateTargetPod(tools.GetDefaultKubeConfig(), *podName, *namespace)
-	so := net.SidecarOpt{
-		SidecarPort: 8000,
-		ServicePort: 80,
-		LocalIP:     "127.0.0.1",
-		PodIp:       targetPod.Status.PodIP,
-		NodeIp:      targetPod.Status.HostIP,
-	}
+	net.GetRequestOverSidecarEvent(sidecarPid, servicePid, portList, *podName)
 
-	net.GetKernelNetworkEvent(pidList, so, *podName)
+	//targetPod, err := tools.LocateTargetPod(tools.GetDefaultKubeConfig(), *podName, *namespace)
+	//so := net.SidecarOpt{
+	//	SidecarPort: 8000,
+	//	ServicePort: 80,
+	//	LocalIP:     "127.0.0.1",
+	//	PodIp:       targetPod.Status.PodIP,
+	//	NodeIp:      targetPod.Status.HostIP,
+	//}
+	//
+	//net.GetKernelNetworkEvent(pidList, so, *podName)
 }

--- a/eBPF_Supermarket/sidecar/perf/net/stack.go
+++ b/eBPF_Supermarket/sidecar/perf/net/stack.go
@@ -212,6 +212,7 @@ func monitorLoopInPod(heap *map[ConnectIdType]InPodConnectionOverall, timeout ti
 				allSpan := t.StartSpan(
 					"Inner Pod",
 					opentracing.StartTime(TimeOffset.Add(conn.Ce.toService[0].Time)),
+					opentracing.Tag{Key: "Connection ID", Value: strconv.Itoa(int(connectId))},
 				)
 
 				connectionEstablishmentSpan := t.StartSpan(

--- a/eBPF_Supermarket/sidecar/policy/pod.go
+++ b/eBPF_Supermarket/sidecar/policy/pod.go
@@ -1,0 +1,1 @@
+package policy

--- a/eBPF_Supermarket/sidecar/tools/container.go
+++ b/eBPF_Supermarket/sidecar/tools/container.go
@@ -57,14 +57,15 @@ func GetAllProcessFromContainer(containerStatus v1.ContainerStatus, nodeContaine
 	fmt.Println("[INFO] Found pid", initPid, "from container", containerID)
 	if IsInMinikubeMode() {
 		fmt.Println("[INFO] Minikube mode detected...")
-		childProcesses, err := FindChildProcessesUnderMinikubeWithDockerDriver(initPid)
+		if MinikubePid < 0 {
+			return nil, fmt.Errorf("minikube uninitialized")
+		}
+		oldInitPid := initPid
+		initPid, err = GetPidUnderRootPidNamespace(MinikubePid, initPid)
+		fmt.Printf("[INFO] Minikube process map %d -> %d\n", oldInitPid, initPid)
 		if err != nil {
 			return nil, err
 		}
-
-		resProcesses := append([]*process.Process{{Pid: int32(initPid)}}, childProcesses...)
-		fmt.Println("[INFO] Got PIDs under Minikube:", resProcesses)
-		return resProcesses, nil
 	}
 
 	initProcess, err := process.NewProcess(int32(initPid))


### PR DESCRIPTION
There are still some problems when using PID under certain namespace when tracing sidecar network events. Concretely, it always returns `-EINVAL`. So changed to trace with global PID.