### PR TITLE
The default config.toml should be at /root not / in ebpf_dns_cache .

### DIFF
--- a/eBPF_Supermarket/ebpf_dns_cache/README.md
+++ b/eBPF_Supermarket/ebpf_dns_cache/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/linuxkerneltravel/lmp.git
 cd lmp/eBPF_Supermarket/ebpf_dns_cache
 docker build . -t ebpf-dns-cache
 # config.toml 的设置可以参考当前目录下 config.toml
-docker run --privileged=true --net=host -v /path/to/config.toml:/config.toml ebpf-dns-cache:latest 
+docker run --privileged=true --net=host -v /path/to/config.toml:/root/config.toml ebpf-dns-cache:latest 
 ```
 
 1. 在本地自行编译


### PR DESCRIPTION
# Pull Request Template

## Description

The default config.toml should be at `/root` not `/` in ebpf_dns_cache .

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

  Yes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
