### PR TITLE
Add libbpf-bootstrap-android to directly support amd64 cross-compile to Android aarch64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "eBPF_Supermarket/eBPF_proc_image/libbpf-bootstrap"]
 	path = eBPF_Supermarket/eBPF_proc_image/libbpf-bootstrap
 	url = https://github.com/libbpf/libbpf-bootstrap.git
+[submodule "eBPF_Hub/libbpf-bootstrap-android"]
+	path = eBPF_Hub/libbpf-bootstrap-android
+	url = https://github.com/JiaHuann/libbpf-bootstrap-android


### PR DESCRIPTION
# Goal
Recognizing the challenges outlined in [#144](https://github.com/libbpf/libbpf-bootstrap/issues/144) on the `libbpf-bootstrap` repository, where significant effort is required to cross-compile AMD64 eBPF programs to AArch64, especially in the context of user programs for the Android platform (which lacks GCC support after Android 8), I've taken the initiative to develop `libbpf-bootstrap-android` to simplify this cross-compilation process.

## Additional Features
In cases where vendors don't expose the `"CONFIG_BTF_DEBUG_INFO"` configuration option to user phones, I've implemented certain modifications to support the use of external BTF (BPF Type Format) files. This enhancement substantially enhances efficiency. Now, it's possible to build a generic Android kernel with this configuration. Subsequently, the resulting vmlinux and BTF files can be deployed to the device. Although a direct push of these files to the phone isn't the recommended approach, an alternative option is provided through [BTFhubForAndroid](https://github.com/SeeFlowerX/BTFHubForAndroid).

I would greatly appreciate your feedback on these changes and enhancements. 