### PR TITLE
mem_watcher：为写入缓冲区的数据添加过滤

### DIFF
--- a/eBPF_Supermarket/Memory_Subsystem/applications/mem_watcher/procstat.bpf.c
+++ b/eBPF_Supermarket/Memory_Subsystem/applications/mem_watcher/procstat.bpf.c
@@ -16,6 +16,13 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 
 struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 256 * 1024);
+	__type(key, pid_t);
+	__type(value, int);
+} last_val SEC(".maps");
+
+struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 256 * 1024);
 } rb SEC(".maps");
@@ -32,6 +39,21 @@ int BPF_KPROBE(finish_task_switch, struct task_struct *prev) {
 	pid_t pid = bpf_get_current_pid_tgid() >> 32;
 	if (pid == user_pid)
 		return 0;
+
+	pid_t p_pid = BPF_CORE_READ(prev, pid);
+	if (p_pid == user_pid)
+		return 0;
+	
+	int val = 1;
+	int *last_pid;
+	last_pid = bpf_map_lookup_elem(&last_val, &p_pid);
+	if (!last_pid) {
+		bpf_map_update_elem(&last_val, &p_pid, &val, BPF_ANY);
+	}
+	else if(*last_pid == val) {
+		return 0;
+	}
+
 	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
 	if (!e)
 		return 0;


### PR DESCRIPTION
为了消除输出时的重复信息，进行了一些修改。
paf工具修改为当flag（申请页面时的权限标志）不同时，才将数据写入rb缓冲区。
pr工具修改为当reclaimed（已经回收的页面数量）有变化时，才将数据写入rb缓冲区。
procstat工具改为当pid不同时，才将数据写入缓冲区。
sysstat工具同样也进行了修改，消除冗余结果。