### PR TITLE
mem_watcher：添加cma代码

### DIFF
--- a/eBPF_Supermarket/mem_watcher/cma/Makefile
+++ b/eBPF_Supermarket/mem_watcher/cma/Makefile
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../libbpf-bootstrap/libbpf/src)
+BPFTOOL_SRC := $(abspath ../libbpf-bootstrap/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../libbpf-bootstrap/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = cma_monitor
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS)
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:
+

--- a/eBPF_Supermarket/mem_watcher/cma/cma_monitor.bpf.c
+++ b/eBPF_Supermarket/mem_watcher/cma/cma_monitor.bpf.c
@@ -1,0 +1,62 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "cma_monitor.h"
+
+#define INTERVAL_MAX 6U
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, unsigned);
+	__type(value, u64);
+} count_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} time_map SEC(".maps");
+
+
+SEC("kretprobe/cma_alloc")
+int BPF_KRETPROBE(cma_alloc)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 ts = bpf_ktime_get_ns();
+
+	bpf_map_update_elem(&time_map, &pid, &ts, BPF_ANY);
+	
+	return 0;
+}
+
+SEC("kprobe/alloc_contig_range")
+int BPF_KRETPROBE(alloc_contig_range)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 tm = bpf_ktime_get_ns();
+	u64 *tsp = bpf_map_lookup_elem(&time_map, &pid);
+	
+	if (tsp)
+		tm -= *tsp;
+	else
+		return 1;
+
+	unsigned key = tm / 10000000;
+	if (key > INTERVAL_MAX - 1)
+		key = INTERVAL_MAX - 1;
+	
+	u64 *value = bpf_map_lookup_elem(&count_map, &key);
+	if (value)
+		*value += 1;
+	else {
+		u64 init_value = 1;
+		bpf_map_update_elem(&count_map, &key, &init_value, BPF_ANY);
+	}	
+
+	bpf_map_delete_elem(&time_map, &pid);
+
+	return 0;
+}

--- a/eBPF_Supermarket/mem_watcher/cma/cma_monitor.c
+++ b/eBPF_Supermarket/mem_watcher/cma/cma_monitor.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+//#include <bpf/bpf_load.h>
+#include "cma_monitor.h"
+#include "cma_monitor.skel.h"
+
+#define INTERVAL_MAX 6U
+
+int main(int argc, char **argv)
+{
+	/*
+	char file_name[200];
+
+	snprintf(file_name, sizeof(file_name), "%s_kern.o", argv[0]);
+	if (load_bpf_file(file_name)) {
+		printf("%s", bpf_log_buf);
+
+		return 1;
+	}*/
+	struct cma_monitor_bpf *skel = cma_monitor_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+	int fd = bpf_map__fd(skel->maps.time_map);
+	int key;
+
+	for (;;) {
+		sleep(5);
+
+		for (key = 0; key < INTERVAL_MAX; key++) {
+			unsigned long long value = 0;
+			bpf_map_lookup_elem(fd, &key, &value);
+
+			if (key < INTERVAL_MAX - 1)
+				printf("Range %dms - %dms\tCount:%llu\n",
+					       	key * 10, (key + 1) * 10, value);
+			else 
+				printf("Over  50ms\t\tCount:%llu\n", value);
+		}
+
+		printf("=========================================\n");
+	}
+
+	return 0;
+}

--- a/eBPF_Supermarket/mem_watcher/cma/cma_monitor.h
+++ b/eBPF_Supermarket/mem_watcher/cma/cma_monitor.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#ifndef __CMA_MONITOR_H
+#define __CMA_MONTOR_H
+
+
+
+
+
+#endif /* __CMA_MONTOR_H */

--- a/eBPF_Supermarket/mem_watcher/ion/Makefile
+++ b/eBPF_Supermarket/mem_watcher/ion/Makefile
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../libbpf-bootstrap/libbpf/src)
+BPFTOOL_SRC := $(abspath ../libbpf-bootstrap/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../libbpf-bootstrap/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = ion_monitor
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS)
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:
+

--- a/eBPF_Supermarket/mem_watcher/ion/ion_monitor.bpf.c
+++ b/eBPF_Supermarket/mem_watcher/ion/ion_monitor.bpf.c
@@ -1,0 +1,63 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "ion_monitor.h"
+
+#define INTERVAL_MAX 6U
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, unsigned);
+	__type(value, u64);
+} count_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} time_map SEC(".maps");
+
+SEC("kprobe/ion_alloc")
+int bpf_prog1(void *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u64 time = bpf_ktime_get_ns();
+	u64 ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&time_map, &pid, &ts, BPF_ANY);
+	
+	return 0;
+}
+
+SEC("kprobe/ion_ioctl")
+int bpf_prog2(void *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u64 tm = bpf_ktime_get_ns();
+	
+	u64 *tsp = bpf_map_lookup_elem(&time_map, &pid);
+	if (tsp) 
+		tm -= *tsp;
+	else 
+		return -1;
+	
+	unsigned key = tm / 10000000;//10ms为区间单位
+	if (key > INTERVAL_MAX - 1)
+		key = INTERVAL_MAX - 1;
+	u64 *value = bpf_map_lookup_elem(&count_map,&key);
+	if (value) {
+		*value += 1;
+	} else {
+		u64 init_value = 1;
+		bpf_map_update_elem(&count_map, &key, &init_value, BPF_ANY);
+	}
+	
+	bpf_map_delete_elem(&time_map, &pid);
+	
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/eBPF_Supermarket/mem_watcher/ion/ion_monitor.c
+++ b/eBPF_Supermarket/mem_watcher/ion/ion_monitor.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+//#include <bpf/bpf_load.h>
+#include "ion_monitor.h"
+#include "ion_monitor.skel.h"
+#include <linux/bpf.h>
+
+
+
+#define INTERVAL_MAX 6U
+int main(int argc, char **argv)
+{
+	/*
+	char file_name[200];
+
+	snprintf(file_name, sizeof(file_name), "%s_kern.o", argv[0]);
+	if (load_bpf_file(file_name)) {
+		printf("%s", bpf_log_buf);
+
+		return 1;
+	}*/
+	struct ion_monitor_bpf *skel = ion_monitor_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	int fd = bpf_map__fd(skel->maps.time_map);
+	int key;
+	
+	for(;;) {
+		sleep(10);
+		
+		for (key = 0; key < INTERVAL_MAX; key++) {
+			unsigned long long value = 0;
+			bpf_map_lookup_elem(fd, &key, &value);
+			if (key < INTERVAL_MAX - 1)
+				printf("Range %dms - %dms\tCount:%llu\n", 
+					key * 10, (key + 1) * 10, value);
+			else 
+				printf("Over  50ms\t\tCount:%llu\n", value);
+		}
+		
+		printf("==========================================\n");
+	}
+	
+	return 0;
+}
+
+
+
+

--- a/eBPF_Supermarket/mem_watcher/ion/ion_monitor.h
+++ b/eBPF_Supermarket/mem_watcher/ion/ion_monitor.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#ifndef __ION_MONITOR_H
+#define __ION_MONITOR_H
+
+
+
+
+
+#endif /* __ION_MONTOR_H */

--- a/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.bpf.c
+++ b/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.bpf.c
@@ -1,0 +1,62 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "cma_monitor.h"
+
+#define INTERVAL_MAX 6U
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, unsigned);
+	__type(value, u64);
+} count_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} time_map SEC(".maps");
+
+
+SEC("kretprobe/cma_alloc")
+int BPF_KRETPROBE(cma_alloc)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 ts = bpf_ktime_get_ns();
+
+	bpf_map_update_elem(&time_map, &pid, &ts, BPF_ANY);
+	
+	return 0;
+}
+
+SEC("kprobe/alloc_contig_range")
+int BPF_KRETPROBE(alloc_contig_range)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 tm = bpf_ktime_get_ns();
+	u64 *tsp = bpf_map_lookup_elem(&time_map, &pid);
+	
+	if (tsp)
+		tm -= *tsp;
+	else
+		return 1;
+
+	unsigned key = tm / 10000000;
+	if (key > INTERVAL_MAX - 1)
+		key = INTERVAL_MAX - 1;
+	
+	u64 *value = bpf_map_lookup_elem(&count_map, &key);
+	if (value)
+		*value += 1;
+	else {
+		u64 init_value = 1;
+		bpf_map_update_elem(&count_map, &key, &init_value, BPF_ANY);
+	}	
+
+	bpf_map_delete_elem(&time_map, &pid);
+
+	return 0;
+}

--- a/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.c
+++ b/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.c
@@ -1,0 +1,51 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+//#include <bpf/bpf_load.h>
+#include "cma_monitor.h"
+#include "cma_monitor.skel.h"
+
+#define INTERVAL_MAX 6U
+
+int main(int argc, char **argv)
+{
+	/*
+	char file_name[200];
+
+	snprintf(file_name, sizeof(file_name), "%s_kern.o", argv[0]);
+	if (load_bpf_file(file_name)) {
+		printf("%s", bpf_log_buf);
+
+		return 1;
+	}*/
+	struct cma_monitor_bpf *skel = cma_monitor_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+	int fd = bpf_map__fd(skel->maps.time_map);
+	int key;
+
+	for (;;) {
+		sleep(5);
+
+		for (key = 0; key < INTERVAL_MAX; key++) {
+			unsigned long long value = 0;
+			bpf_map_lookup_elem(fd, &key, &value);
+
+			if (key < INTERVAL_MAX - 1)
+				printf("Range %dms - %dms\tCount:%llu\n",
+					       	key * 10, (key + 1) * 10, value);
+			else 
+				printf("Over  50ms\t\tCount:%llu\n", value);
+		}
+
+		printf("=========================================\n");
+	}
+
+	return 0;
+}

--- a/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.h
+++ b/eBPF_Supermarket/mem_watcher/page_fault/cma/cma_monitor.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#ifndef __CMA_MONITOR_H
+#define __CMA_MONTOR_H
+
+
+
+
+
+#endif /* __CMA_MONTOR_H */

--- a/eBPF_Supermarket/mem_watcher/page_fault/ion/Makefile
+++ b/eBPF_Supermarket/mem_watcher/page_fault/ion/Makefile
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../libbpf-bootstrap/libbpf/src)
+BPFTOOL_SRC := $(abspath ../libbpf-bootstrap/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../libbpf-bootstrap/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = ion_monitor
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS)
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:
+

--- a/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.bpf.c
+++ b/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.bpf.c
@@ -1,0 +1,63 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "ion_monitor.h"
+
+#define INTERVAL_MAX 6U
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, unsigned);
+	__type(value, u64);
+} count_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u64);
+} time_map SEC(".maps");
+
+SEC("kprobe/ion_alloc")
+int bpf_prog1(void *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u64 time = bpf_ktime_get_ns();
+	u64 ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&time_map, &pid, &ts, BPF_ANY);
+	
+	return 0;
+}
+
+SEC("kprobe/ion_ioctl")
+int bpf_prog2(void *ctx)
+{
+	u32 pid = bpf_get_current_pid_tgid() >> 32;
+	u64 tm = bpf_ktime_get_ns();
+	
+	u64 *tsp = bpf_map_lookup_elem(&time_map, &pid);
+	if (tsp) 
+		tm -= *tsp;
+	else 
+		return -1;
+	
+	unsigned key = tm / 10000000;//10ms为区间单位
+	if (key > INTERVAL_MAX - 1)
+		key = INTERVAL_MAX - 1;
+	u64 *value = bpf_map_lookup_elem(&count_map,&key);
+	if (value) {
+		*value += 1;
+	} else {
+		u64 init_value = 1;
+		bpf_map_update_elem(&count_map, &key, &init_value, BPF_ANY);
+	}
+	
+	bpf_map_delete_elem(&time_map, &pid);
+	
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.c
+++ b/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+//#include <bpf/bpf_load.h>
+#include "ion_monitor.h"
+#include "ion_monitor.skel.h"
+#include <linux/bpf.h>
+
+
+
+#define INTERVAL_MAX 6U
+int main(int argc, char **argv)
+{
+	/*
+	char file_name[200];
+
+	snprintf(file_name, sizeof(file_name), "%s_kern.o", argv[0]);
+	if (load_bpf_file(file_name)) {
+		printf("%s", bpf_log_buf);
+
+		return 1;
+	}*/
+	struct ion_monitor_bpf *skel = ion_monitor_bpf__open_and_load();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	int fd = bpf_map__fd(skel->maps.time_map);
+	int key;
+	
+	for(;;) {
+		sleep(10);
+		
+		for (key = 0; key < INTERVAL_MAX; key++) {
+			unsigned long long value = 0;
+			bpf_map_lookup_elem(fd, &key, &value);
+			if (key < INTERVAL_MAX - 1)
+				printf("Range %dms - %dms\tCount:%llu\n", 
+					key * 10, (key + 1) * 10, value);
+			else 
+				printf("Over  50ms\t\tCount:%llu\n", value);
+		}
+		
+		printf("==========================================\n");
+	}
+	
+	return 0;
+}
+
+
+
+

--- a/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.h
+++ b/eBPF_Supermarket/mem_watcher/page_fault/ion/ion_monitor.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2022 Jacky Yin */
+#ifndef __ION_MONITOR_H
+#define __ION_MONITOR_H
+
+
+
+
+
+#endif /* __ION_MONTOR_H */


### PR DESCRIPTION
添加cma代码 用于在Linux内核中跟踪和监视CMA（Contiguous Memory Allocator）的内存分配情况。
添加ion代码 用于在Linux内核中跟踪和监视ION内存分配和释放的情况。
