### PR TITLE
mem_watcher:添加其他的用户态内存泄漏检测接口

### DIFF
--- a/eBPF_Supermarket/Memory_Subsystem/applications/mem_watcher/mem_watcher.c
+++ b/eBPF_Supermarket/Memory_Subsystem/applications/mem_watcher/mem_watcher.c
@@ -414,11 +414,43 @@ static int handle_event_sysstat(void *ctx, void *data, size_t data_sz) {
 pid_t own_pid;
 
 int attach_uprobes(struct memleak_bpf *skel) {
-	ATTACH_UPROBE_CHECKED(skel, malloc, malloc_enter);
-	ATTACH_URETPROBE_CHECKED(skel, malloc, malloc_exit);
-	ATTACH_UPROBE_CHECKED(skel, free, free_enter);
+    ATTACH_UPROBE_CHECKED(skel, malloc, malloc_enter);
+    ATTACH_URETPROBE_CHECKED(skel, malloc, malloc_exit);
+    ATTACH_UPROBE_CHECKED(skel, free, free_enter);
 
-	return 0;
+    ATTACH_UPROBE_CHECKED(skel, posix_memalign, posix_memalign_enter);
+    ATTACH_URETPROBE_CHECKED(skel, posix_memalign, posix_memalign_exit);
+
+    ATTACH_UPROBE_CHECKED(skel, calloc, calloc_enter);
+    ATTACH_URETPROBE_CHECKED(skel, calloc, calloc_exit);
+
+    ATTACH_UPROBE_CHECKED(skel, realloc, realloc_enter);
+    ATTACH_URETPROBE_CHECKED(skel, realloc, realloc_exit);
+
+    ATTACH_UPROBE_CHECKED(skel, mmap, mmap_enter);
+    ATTACH_URETPROBE_CHECKED(skel, mmap, mmap_exit);
+
+    ATTACH_UPROBE_CHECKED(skel, memalign, memalign_enter);
+    ATTACH_URETPROBE_CHECKED(skel, memalign, memalign_exit);
+
+    ATTACH_UPROBE_CHECKED(skel, free, free_enter);
+    ATTACH_UPROBE_CHECKED(skel, munmap, munmap_enter);
+
+    // the following probes are intentinally allowed to fail attachment
+
+    // deprecated in libc.so bionic
+    ATTACH_UPROBE(skel, valloc, valloc_enter);
+    ATTACH_URETPROBE(skel, valloc, valloc_exit);
+
+    // deprecated in libc.so bionic
+    ATTACH_UPROBE(skel, pvalloc, pvalloc_enter);
+    ATTACH_URETPROBE(skel, pvalloc, pvalloc_exit);
+
+    // added in C11
+    ATTACH_UPROBE(skel, aligned_alloc, aligned_alloc_enter);
+    ATTACH_URETPROBE(skel, aligned_alloc, aligned_alloc_exit);
+
+    return 0;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
添加其他用户态内存分配接口的内存泄露检测
void *malloc(size_t size);
void *calloc(size_t nmemb, size_t size);
void *realloc(void *ptr, size_t size);
void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
void *memalign(size_t alignment, size_t size);
void *valloc(size_t size);
void *pvalloc(size_t size);
void *aligned_alloc(size_t alignment, size_t size);
int posix_memalign(void **memptr, size_t alignment, size_t size);