### PR TITLE
cpu_watcher：schedule_delay增加阈值选项&&增加controller功能

### DIFF
--- a/.github/workflows/ebpf_cpu_watcher.yml
+++ b/.github/workflows/ebpf_cpu_watcher.yml
@@ -31,3 +31,9 @@ jobs:
           cd eBPF_Supermarket/CPU_Subsystem/cpu_watcher/
           make 
           sudo ./cpu_watcher 
+
+       - name: Run test_cpuwatcher
+        run: |
+          cd eBPF_Supermarket/CPU_Subsystem/cpu_watcher/test
+          make
+          ./test_cpuwatcher

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/Makefile
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/Makefile
@@ -44,6 +44,7 @@ ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
 
 APPS =cs_delay sar sc_delay preempt schedule_delay mq_delay
 TARGETS=cpu_watcher
+CONTROLLER := controller
 
 SRC_DIR = ./include
 
@@ -81,12 +82,12 @@ $(call allow-override,CC,$(CROSS_COMPILE)cc)
 $(call allow-override,LD,$(CROSS_COMPILE)ld)
 
 .PHONY: all
-all: $(TARGETS)
+all: $(CONTROLLER) $(TARGETS)
 
 .PHONY: clean
 clean:
 	$(call msg,CLEAN)
-	$(Q)rm -rf $(OUTPUT) $(TARGETS)
+	$(Q)rm -rf $(OUTPUT) $(TARGETS) $(CONTROLLER)
 
 $(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
 	$(call msg,MKDIR,$@)
@@ -132,11 +133,19 @@ $(OUTPUT)/%.o: $(SRC_DIR)/%.c | $(OUTPUT)
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
+$(OUTPUT)/%.o: $(CONTROLLER).c | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
 $(OUTPUT)/$(TARGETS).o: $(TARGETS).c $(APPS) | $(OUTPUT)
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
 # Build application binary
+$(CONTROLLER): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $^ $(ALL_LDFLAGS) -lstdc++ -lelf -lz -o $@
+	
 $(TARGETS): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
 	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lstdc++ -lelf -lz -o $@

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/cs_delay.bpf.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/cs_delay.bpf.c
@@ -21,9 +21,10 @@
 #include "cpu_watcher.h"
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
+const int ctrl_key = 0;
 //记录时间戳；
 BPF_ARRAY(start,int,u64,1);
+BPF_ARRAY(cs_ctrl_map,int,struct cs_ctrl,1);
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 256 * 1024);

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/mq_delay.bpf.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/mq_delay.bpf.c
@@ -23,10 +23,11 @@
 
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
-
+const int ctrl_key = 0;
 BPF_HASH(send_msg1,pid_t,struct send_events,1024);//记录pid->u_msg_ptr的关系；do_mq_timedsend入参
 BPF_HASH(send_msg2,u64,struct send_events,1024);//记录msg->time的关系；
 BPF_HASH(rcv_msg1,pid_t,struct rcv_events,1024);//记录pid->u_msg_ptr的关系；do_mq_timedsend入参
+BPF_ARRAY(mq_ctrl_map,int,struct mq_ctrl,1);
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	__uint(max_entries, 256 * 1024);

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/schedule_delay.bpf.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/schedule_delay.bpf.c
@@ -23,14 +23,14 @@
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 #define TASK_RUNNING			0x0000
 
-BPF_HASH(has_scheduled,struct proc_id, bool, 10240);
-BPF_HASH(enter_schedule,struct proc_id, struct schedule_event, 10240);
-BPF_ARRAY(sys_schedule,int,struct sum_schedule,1);
-
+BPF_HASH(has_scheduled,struct proc_id, bool, 10240);//记录该进程是否调度过
+BPF_HASH(enter_schedule,struct proc_id, struct schedule_event, 10240);//记录该进程上运行队列的时间
+BPF_ARRAY(sys_schedule,int,struct sum_schedule,1);//记录整个系统的调度延迟
+BPF_ARRAY(threshold_schedule,int,struct proc_schedule,10240);//记录每个进程的调度延迟
 
 SEC("tp_btf/sched_wakeup")
 int BPF_PROG(sched_wakeup, struct task_struct *p) {
-    pid_t pid = BPF_CORE_READ(p, pid);
+    pid_t pid = p->pid;
     int cpu = bpf_get_smp_processor_id();
     struct schedule_event *schedule_event;
     struct proc_id id= {};
@@ -56,7 +56,7 @@ int BPF_PROG(sched_wakeup, struct task_struct *p) {
 
 SEC("tp_btf/sched_wakeup_new")
 int BPF_PROG(sched_wakeup_new, struct task_struct *p) {
-    pid_t pid = BPF_CORE_READ(p, pid);
+    pid_t pid = p->pid;
     int cpu = bpf_get_smp_processor_id();
     struct proc_id id= {};
     u64 current_time = bpf_ktime_get_ns();
@@ -86,17 +86,17 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
     struct schedule_event *schedule_event;
     struct sum_schedule *sum_schedule;
     int key = 0;
-    struct proc_id next_id= {};
+    struct proc_id next_id = {};
     u64 delay;
     if (prev_state == TASK_RUNNING) {
-        struct proc_id prev_pd= {};
+        struct proc_id prev_pd = {};
         prev_pd.pid = prev_pid;
         if (prev_pid == 0) {
             prev_pd.cpu_id = prev_cpu;
-        }    
+        }
         schedule_event = bpf_map_lookup_elem(&enter_schedule, &prev_pd);
         if (!schedule_event) {
-            struct schedule_event schedule_event2 ;
+            struct schedule_event schedule_event2;
             bool issched = false;
             schedule_event2.pid = prev_pid;
             schedule_event2.count = 1;
@@ -113,44 +113,49 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
         next_id.cpu_id = next_cpu;
     }
     schedule_event = bpf_map_lookup_elem(&enter_schedule, &next_id);
-    if (!schedule_event)  return 0;
+    if (!schedule_event) return 0;
     issched = bpf_map_lookup_elem(&has_scheduled, &next_id);
-    if (!issched)  return 0;   
+    if (!issched) return 0;
     if (*issched) {
         schedule_event->count++;
     } else {
         *issched = true;
-    }   
+    }
     delay = current_time - schedule_event->enter_time;
+    struct proc_schedule proc_schedule;
+    proc_schedule.pid = next_pid;
+    proc_schedule.delay = delay;
+    bpf_probe_read_kernel_str(&proc_schedule.proc_name, sizeof(proc_schedule.proc_name), next->comm);
+    bpf_map_update_elem(&threshold_schedule, &key, &proc_schedule, BPF_ANY);
     sum_schedule = bpf_map_lookup_elem(&sys_schedule, &key);
     if (!sum_schedule) {
-        struct sum_schedule sum_schedule= {};
+        struct sum_schedule sum_schedule = {};
         sum_schedule.sum_count++;
         sum_schedule.sum_delay += delay;
-        if (delay > sum_schedule.max_delay){
+        if (delay > sum_schedule.max_delay) {
             sum_schedule.max_delay = delay;
-            if(next->pid!=0){
-                sum_schedule.pid_max = next->pid;
+            if (next->pid != 0) {
+                bpf_probe_read_kernel_str(&sum_schedule.proc_name_max, sizeof(sum_schedule.proc_name_max), next->comm);
             }
-        }else if (sum_schedule.min_delay == 0 || delay < sum_schedule.min_delay)
+        } else if (sum_schedule.min_delay == 0 || delay < sum_schedule.min_delay) {
             sum_schedule.min_delay = delay;
-            if(next->pid!=0){
-                sum_schedule.pid_min = next->pid;
+            if (next->pid != 0) {
+                bpf_probe_read_kernel_str(&sum_schedule.proc_name_min, sizeof(sum_schedule.proc_name_min), next->comm);
             }
+        }
         bpf_map_update_elem(&sys_schedule, &key, &sum_schedule, BPF_ANY);
     } else {
         sum_schedule->sum_count++;
         sum_schedule->sum_delay += delay;
-        if (delay > sum_schedule->max_delay){
+        if (delay > sum_schedule->max_delay) {
             sum_schedule->max_delay = delay;
-            if(next->pid!=0){
-                sum_schedule->pid_max = next->pid;
-            }
-        }else if (sum_schedule->min_delay == 0 || delay < sum_schedule->min_delay)
+            bpf_probe_read_kernel_str(&sum_schedule->proc_name_max, sizeof(sum_schedule->proc_name_max), next->comm);
+        } else if (sum_schedule->min_delay == 0 || delay < sum_schedule->min_delay) {
             sum_schedule->min_delay = delay;
-            if(next->pid!=0){
-                sum_schedule->pid_min = next->pid;
+            if (next->pid != 0) {
+                bpf_probe_read_kernel_str(&sum_schedule->proc_name_min, sizeof(sum_schedule->proc_name_min), next->comm);
             }
+        }
     }
     return 0;
 }

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/schedule_delay.bpf.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/bpf/schedule_delay.bpf.c
@@ -22,14 +22,20 @@
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";
 #define TASK_RUNNING			0x0000
-
+const int ctrl_key = 0;
 BPF_HASH(has_scheduled,struct proc_id, bool, 10240);//记录该进程是否调度过
 BPF_HASH(enter_schedule,struct proc_id, struct schedule_event, 10240);//记录该进程上运行队列的时间
 BPF_ARRAY(sys_schedule,int,struct sum_schedule,1);//记录整个系统的调度延迟
 BPF_ARRAY(threshold_schedule,int,struct proc_schedule,10240);//记录每个进程的调度延迟
+BPF_ARRAY(schedule_ctrl_map,int,struct schedule_ctrl,1);
 
 SEC("tp_btf/sched_wakeup")
 int BPF_PROG(sched_wakeup, struct task_struct *p) {
+    struct schedule_ctrl *sched_ctrl;
+	sched_ctrl = bpf_map_lookup_elem(&schedule_ctrl_map,&ctrl_key);
+	if(!sched_ctrl || !sched_ctrl->schedule_func)
+		return 0;
+
     pid_t pid = p->pid;
     int cpu = bpf_get_smp_processor_id();
     struct schedule_event *schedule_event;
@@ -56,6 +62,11 @@ int BPF_PROG(sched_wakeup, struct task_struct *p) {
 
 SEC("tp_btf/sched_wakeup_new")
 int BPF_PROG(sched_wakeup_new, struct task_struct *p) {
+    struct schedule_ctrl *sched_ctrl;
+	sched_ctrl = bpf_map_lookup_elem(&schedule_ctrl_map,&ctrl_key);
+	if(!sched_ctrl || !sched_ctrl->schedule_func)
+		return 0;
+
     pid_t pid = p->pid;
     int cpu = bpf_get_smp_processor_id();
     struct proc_id id= {};
@@ -76,6 +87,11 @@ int BPF_PROG(sched_wakeup_new, struct task_struct *p) {
 
 SEC("tp_btf/sched_switch")
 int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_struct *next) {
+    struct schedule_ctrl *sched_ctrl;
+	sched_ctrl = bpf_map_lookup_elem(&schedule_ctrl_map,&ctrl_key);
+	if(!sched_ctrl || !sched_ctrl->schedule_func)
+		return 0;
+
     u64 current_time = bpf_ktime_get_ns();
     pid_t prev_pid = prev->pid;
     unsigned int prev_state = prev->__state;
@@ -162,6 +178,11 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
 
 SEC("tracepoint/sched/sched_process_exit")
 int sched_process_exit(void *ctx) {
+    struct schedule_ctrl *sched_ctrl;
+	sched_ctrl = bpf_map_lookup_elem(&schedule_ctrl_map,&ctrl_key);
+	if(!sched_ctrl || !sched_ctrl->schedule_func)
+		return 0;
+
     struct task_struct *p = (struct task_struct *)bpf_get_current_task();
     pid_t pid = BPF_CORE_READ(p, pid);
     int cpu = bpf_get_smp_processor_id();

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/controller.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/controller.c
@@ -1,0 +1,250 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: albert_xuu@163.com zhangxy1016304@163.com zhangziheng0525@163.com
+//
+// used to control the execution of proc_image tool
+#include <stdio.h>
+#include <stdbool.h>
+#include <argp.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <signal.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "cpu_watcher_helper.h"
+
+static struct env {
+    // 1代表activate；2代表unactivate；3代表finish
+    int usemode;
+    bool SAR;
+    bool CS_DELAY;
+    bool SYSCALL_DELAY;
+    bool MIN_US_SET;
+    int MIN_US;
+    bool PREEMPT;
+    bool SCHEDULE_DELAY;
+    bool MQ_DELAY;
+    int freq;
+} env = {
+    .usemode = 0,
+    .SAR = false,
+    .CS_DELAY = false,
+    .SYSCALL_DELAY = false,
+    .MIN_US_SET = false,
+    .MIN_US = 10000,
+    .PREEMPT = false,
+    .SCHEDULE_DELAY = false,
+    .MQ_DELAY = false,
+    .freq = 99,
+};
+
+const char argp_program_doc[] ="Trace process to get cpu watcher.\n";
+
+static const struct argp_option opts[] = {
+    { "activate", 'a', NULL, 0, "Set startup policy of proc_image tool" },
+    { "unactivate", 'u', NULL, 0, "Initialize to the original unactivated state" },
+    { "finish", 'f', NULL, 0, "Finish to run eBPF tool" },
+    {"libbpf_sar", 's', 0, 0, "Print sar_info (the data of cpu)" },
+    {"cs_delay", 'c', 0, 0, "Print cs_delay (the data of cpu)" },
+    {"syscall_delay", 'S', 0, 0, "Print syscall_delay (the data of syscall)" },
+    {"preempt_time", 'p', 0, 0, "Print preempt_time (the data of preempt_schedule)" },
+    {"schedule_delay", 'd', 0, 0, "Print schedule_delay (the data of cpu)" },
+    {"schedule_delay_min_us_set", 'e', "THRESHOLD", 0, "Print scheduling delays that exceed the threshold (the data of cpu)" },
+    {"mq_delay", 'm', 0, 0, "Print mq_delay(the data of proc)" },    
+	// { "pid", 'p', "PID", 0, "Process ID to trace" },
+    // { "tgid", 'P', "TGID", 0, "Thread group to trace" },
+    // { "cpuid", 'c', "CPUID", 0, "Set For Tracing  per-CPU Process(other processes don't need to set this parameter)" },
+    // { "time", 't', "TIME-SEC", 0, "Max Running Time(0 for infinite)" },
+    // { "myproc", 'm', NULL, 0, "Trace the process of the tool itself (not tracked by default)" },
+    // { "resource", 'r', NULL, 0, "Collects resource usage information about processes" },
+    // { "keytime", 'k', "KEYTIME", 0, "Collects keytime information about processes(0:except CPU kt_info,1:all kt_info,any 0 or 1 when deactivated)" },
+    // { "lock", 'l', NULL, 0, "Collects lock information about processes" },
+    // { "syscall", 's', "SYSCALLS", 0, "Collects syscall sequence (1~50) information about processes(any 1~50 when deactivated)" },
+    // { "schedule", 'S', NULL, 0, "Collects schedule information about processes (trace tool process)" },
+    { NULL, 'h', NULL, OPTION_HIDDEN, "show the full help" },
+    {},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+    switch (key) {
+        case 'a':
+            env.usemode = 1;
+            break;
+        case 'u':
+            env.usemode = 2;
+            break;
+        case 'f':
+            env.usemode = 3;
+            break;
+        case 's':
+            env.SAR = true;
+            break;
+        case 'c':
+            env.CS_DELAY = true;
+            break;
+        case 'S':
+            env.SYSCALL_DELAY = true;
+            break;
+        case 'p':
+            env.PREEMPT = true;
+            break;
+        case 'd':
+            env.SCHEDULE_DELAY = true;
+            break;
+        case 'e':
+            env.MIN_US_SET = true;
+            if (arg) {
+                env.MIN_US = strtol(arg, NULL, 10);
+                if (env.MIN_US <= 0) {
+                    fprintf(stderr, "Invalid value for min_us: %d\n", env.MIN_US);
+                    argp_usage(state);
+                }
+            } else {
+                env.MIN_US = 10000;
+            }
+            break;
+        case 'm':
+            env.MQ_DELAY = true;
+            break;			
+        case 'h':
+				argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+				break;
+        default:
+				return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+int deactivate_mode(){
+    int err;
+
+    if(env.SAR){
+        struct sar_ctrl sar_ctrl = {false,0};
+        err = update_sar_ctrl_map(sar_ctrl);
+        if(err < 0) return err;
+    }
+    if(env.CS_DELAY){
+        struct cs_ctrl cs_ctrl = {false,0};
+        err = update_cs_ctrl_map(cs_ctrl);
+        if(err < 0) return err;
+    }
+    if(env.SYSCALL_DELAY){
+        struct sc_ctrl sc_ctrl = {false,0};
+        err = update_sc_ctrl_map(sc_ctrl);
+        if(err < 0) return err;
+    }
+    if(env.PREEMPT){
+        struct preempt_ctrl preempt_ctrl = {false,0};
+        err = update_preempt_ctrl_map(preempt_ctrl);
+        if(err < 0) return err;
+    }
+    if(env.SCHEDULE_DELAY){
+        struct schedule_ctrl schedule_ctrl = {false,false,10000,0};
+        err = update_schedule_ctrl_map(schedule_ctrl);
+        if(err < 0) return err;
+    }
+    if(env.MQ_DELAY){
+        struct mq_ctrl mq_ctrl = {false,0};
+        err = update_mq_ctrl_map(mq_ctrl);
+        if(err < 0) return err;
+    }    
+    return 0;
+}
+
+static void sig_handler(int signo)
+{
+	deactivate_mode();
+}
+
+int main(int argc, char **argv)
+{
+    int err;
+    static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+
+    err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+    signal(SIGALRM,sig_handler);
+	signal(SIGINT,sig_handler);
+	signal(SIGTERM,sig_handler);
+
+    if(env.usemode == 1){                   // activate mode
+        if(env.SAR){
+            struct sar_ctrl sar_ctrl = {true,SAR_WACTHER};
+            err = update_sar_ctrl_map(sar_ctrl);
+            if(err < 0) return err;
+        }
+
+        if(env.CS_DELAY){
+            struct cs_ctrl cs_ctrl = {true,CS_WACTHER};
+            err = update_cs_ctrl_map(cs_ctrl);
+            if(err < 0) return err;
+        }
+
+        if(env.SYSCALL_DELAY){
+            struct sc_ctrl sc_ctrl = {true,SC_WACTHER};
+            err = update_sc_ctrl_map(sc_ctrl);
+            if(err < 0) return err;
+        }
+
+        if(env.PREEMPT){
+            struct preempt_ctrl preempt_ctrl = {true,PREEMPT_WACTHER};
+            err = update_preempt_ctrl_map(preempt_ctrl);
+            if(err < 0) return err;
+        }
+
+        if(env.SCHEDULE_DELAY){
+            /*
+             *1.未设置env.MIN_US_SET时, prev_watcher = SCHEDULE_WACTHER + 0;输出方式为schedule输出 
+             *2.已设置env.MIN_US_SET时, prev_watcher = SCHEDULE_WACTHER + 1;输出方式为-e输出
+             */
+            struct schedule_ctrl schedule_ctrl = {true,env.MIN_US_SET,env.MIN_US,SCHEDULE_WACTHER+env.MIN_US_SET};
+            err = update_schedule_ctrl_map(schedule_ctrl);
+            if(err < 0) return err;
+        }
+
+        if(env.MQ_DELAY){
+            struct mq_ctrl mq_ctrl = {true,MQ_WACTHER};
+            err = update_mq_ctrl_map(mq_ctrl);
+            if(err < 0) return err;
+        }
+    }else if(env.usemode == 2){             // deactivate mode
+        err = deactivate_mode();
+        if(err<0){
+            fprintf(stderr, "Failed to deactivate\n");
+            return err;
+        }
+    }else if(env.usemode == 3){             // finish mode
+        const char *command = "pkill cpu_watcher";
+        int status = system(command);
+        if (status == -1) {
+            perror("system");
+        }
+    }else{
+        // 输出help信息
+        printf("Please enter the usage mode(activate/deactivate/finish) before selecting the function\n");
+        argp_help(&argp, stderr, ARGP_HELP_LONG, argv[0]);
+    }
+
+    return 0;
+}

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/cpu_watcher.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/cpu_watcher.c
@@ -134,7 +134,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
     switch (key) {
         case 't':
             env.time = strtol(arg, NULL, 10);
-            if(env.time) alarm(env.time);
+            if (env.time) alarm(env.time);
             break;
         case 'i':
             env.period = strtol(arg, NULL, 10);
@@ -565,7 +565,7 @@ static int schedule_print()
         }
         if (info.delay / 1000 > env.MIN_US&&info.pid!=0) { // 默认输出调度延迟大于10ms的
             if (!entry_exists(info.pid, info.proc_name, info.delay / 1000)) {
-                printf("%-10d %-10s %15lld\n", info.pid, info.proc_name, info.delay / 1000);
+                printf("%-10d %-16s %15lld\n", info.pid, info.proc_name, info.delay / 1000);
                 add_entry(info.pid, info.proc_name, info.delay / 1000);
             }
         }
@@ -728,7 +728,8 @@ int main(int argc, char **argv)
 			goto schedule_cleanup;
 		}
 		if(env.MIN_US_SET){
-			printf("%s\n","pid        COMM       schedule_delay/us");
+			printf("调度延时大于%dms的进程:\n",env.MIN_US/1000);
+			printf("%s\n","pid        COMM                   schedule_delay/us");
 		}else{
 			printf("%-8s %s\n",  "  TIME ", "avg_delay/μs     max_delay/μs    max_proc_name    min_delay/μs   min_proc_name");
 		}

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/cpu_watcher.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/cpu_watcher.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <linux/perf_event.h>
 #include <asm/unistd.h>
-#include "cpu_watcher.h"
+#include "cpu_watcher_helper.h"
 #include "sar.skel.h"
 #include "cs_delay.skel.h"
 #include "sc_delay.skel.h"
@@ -60,12 +60,12 @@ static struct env {
     bool SAR;
     bool CS_DELAY;
     bool SYSCALL_DELAY;
-    bool MIN_US_SET;
-    int MIN_US;
     bool PREEMPT;
     bool SCHEDULE_DELAY;
     bool MQ_DELAY;
     int freq;
+    bool EWMA;
+    int cycle;
 } env = {
     .time = 0,
     .period = 1,
@@ -74,12 +74,12 @@ static struct env {
     .SAR = false,
     .CS_DELAY = false,
     .SYSCALL_DELAY = false,
-    .MIN_US_SET = false,
-    .MIN_US = 10000,
     .PREEMPT = false,
     .SCHEDULE_DELAY = false,
     .MQ_DELAY = false,
-    .freq = 99
+    .freq = 99,
+    .EWMA = false,
+    .cycle = 0,
 };
 
 
@@ -90,6 +90,15 @@ struct sc_delay_bpf *sc_skel;
 struct preempt_bpf *preempt_skel;
 struct schedule_delay_bpf *sd_skel;
 struct mq_delay_bpf *mq_skel;
+
+static int csmap_fd;
+static int sarmap_fd;
+static int scmap_fd;
+static int preemptmap_fd;
+static int schedulemap_fd;
+static int mqmap_fd;
+
+//static int prev_watcher = 0;//上一个使用的工具，用于在切换使用功能时，打印不用功能的表头；
 
 u64 softirq = 0;
 u64 irqtime = 0;
@@ -123,8 +132,9 @@ static const struct argp_option opts[] = {
     {"syscall_delay", 'S', 0, 0, "Print syscall_delay (the data of syscall)" },
     {"preempt_time", 'p', 0, 0, "Print preempt_time (the data of preempt_schedule)" },
     {"schedule_delay", 'd', 0, 0, "Print schedule_delay (the data of cpu)" },
-    {"schedule_delay_min_us_set", 'e', "THRESHOLD", 0, "Print scheduling delays that exceed the threshold (the data of cpu)" },
     {"mq_delay", 'm', 0, 0, "Print mq_delay(the data of proc)" },
+    {"ewma", 'E',0,0,"dynamic filte the data"},
+    {"cycle", 'T',"CYCLE",0,"Periods of the ewma"},
     { NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
     { 0 },
 };
@@ -157,21 +167,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
         case 'd':
             env.SCHEDULE_DELAY = true;
             break;
-        case 'e':
-            env.MIN_US_SET = true;
-            if (arg) {
-                env.MIN_US = strtol(arg, NULL, 10);
-                if (env.MIN_US <= 0) {
-                    fprintf(stderr, "Invalid value for min_us: %d\n", env.MIN_US);
-                    argp_usage(state);
-                }
-            } else {
-                env.MIN_US = 10000;
-            }
-            break;
         case 'm':
             env.MQ_DELAY = true;
             break;
+		case 'E':
+			env.EWMA = true;
+			break;
+		case 'T':
+			env.cycle = strtol(arg, NULL, 10);
+			break;			
         case 'h':
             argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
             break;
@@ -479,12 +483,38 @@ static void histogram()
 }
 
 
+struct ewma_info ewma_syscall_delay = {};
 static int syscall_delay_print(void *ctx, void *data,unsigned long data_sz)
 {
+	int err,key = 0;
+	struct sc_ctrl sc_ctrl ={};
+
+	err = bpf_map_lookup_elem(scmap_fd,&key,&sc_ctrl);
+	if (err < 0) {
+		fprintf(stderr, "failed to lookup infos: %d\n", err);
+		return -1;
+	}
+	if(!sc_ctrl.sc_func)	return 0;
 
 	const struct syscall_events *e = data;
-	printf("pid: %-8u comm: %-10s syscall_id: %-8lld delay: %-8lld\n",
-		e->pid,e->comm,e->syscall_id,e->delay);
+	if(e->delay<0||e->delay>1000000) return 0;
+	time_t now = time(NULL);// 获取当前时间
+	struct tm *localTime = localtime(&now);// 将时间转换为本地时间结构	
+
+	if(env.EWMA==0){
+		printf("%02d:%02d:%02d     %-8u %-15lld %-15lld\n",
+			localTime->tm_hour, localTime->tm_min, localTime->tm_sec,
+			e->pid,e->syscall_id,e->delay);
+	}
+	else{
+		ewma_syscall_delay.cycle = env.cycle;
+		if(dynamic_filter(&ewma_syscall_delay,e->delay)){
+			printf("%02d:%02d:%02d     %-8u %-15lld %-15lld\n",
+					localTime->tm_hour, localTime->tm_min, localTime->tm_sec,
+					e->pid,e->syscall_id,e->delay);
+		}
+	}
+
 	return 0;
 }
 
@@ -532,8 +562,36 @@ void add_entry(int pid, const char *comm, long long delay) {
 }
 static int schedule_print()
 {
-    int key = 0;
-	if(env.SCHEDULE_DELAY){
+
+    int err,key = 0;
+	struct schedule_ctrl sd_ctrl = {};
+	err = bpf_map_lookup_elem(schedulemap_fd,&key,&sd_ctrl);
+	if (err < 0) {
+		fprintf(stderr, "failed to lookup infos: %d\n", err);
+		return -1;
+	}
+	if(!sd_ctrl.schedule_func)	return 0;	
+
+	if(sd_ctrl.prev_watcher == SCHEDULE_WACTHER ){
+		printf("%-8s %s\n",  "  TIME ", "avg_delay/μs     max_delay/μs    max_proc_name    min_delay/μs   min_proc_name");
+		sd_ctrl.prev_watcher = SCHEDULE_WACTHER + 9;//打印表头功能关
+		err = bpf_map_update_elem(schedulemap_fd, &key, &sd_ctrl, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+		}
+	}
+	else if(sd_ctrl.prev_watcher == SCHEDULE_WACTHER +1){
+			// printf("sd_ctrl.prev_watcher = %d\n",sd_ctrl.prev_watcher);
+			printf("调度延时大于%dms的进程:\n",sd_ctrl.min_us/1000);
+			printf("%s\n","pid        COMM                   schedule_delay/us");
+		sd_ctrl.prev_watcher = SCHEDULE_WACTHER + 9;//打印表头功能关.
+		err = bpf_map_update_elem(schedulemap_fd, &key, &sd_ctrl, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+		}		
+	}
+
+	if(!sd_ctrl.min_us_set){
 		struct sum_schedule info;
 		int err, fd = bpf_map__fd(sd_skel->maps.sys_schedule);
 		time_t now = time(NULL);
@@ -554,7 +612,8 @@ static int schedule_print()
 			printf("%02d:%02d:%02d  %-15lf %-15lf  %10s %15lf  %15s\n",
 			hour, min, sec, avg_delay / 1000.0, info.max_delay / 1000.0,info.proc_name_max,info.min_delay / 1000.0,info.proc_name_min);
 		}
-	}else if(env.MIN_US_SET){
+	}
+	else{
 		struct proc_schedule info;
         int key = 0;  
         int err, fd = bpf_map__fd(sd_skel->maps.threshold_schedule);
@@ -563,13 +622,14 @@ static int schedule_print()
             fprintf(stderr, "failed to lookup infos: %d\n", err);
             return -1;
         }
-        if (info.delay / 1000 > env.MIN_US&&info.pid!=0) { // 默认输出调度延迟大于10ms的
+        if (info.delay / 1000 > sd_ctrl.min_us&&info.pid!=0) { // 默认输出调度延迟大于10ms的
             if (!entry_exists(info.pid, info.proc_name, info.delay / 1000)) {
                 printf("%-10d %-16s %15lld\n", info.pid, info.proc_name, info.delay / 1000);
                 add_entry(info.pid, info.proc_name, info.delay / 1000);
             }
         }
 	}
+
     return 0;
 }
 
@@ -604,6 +664,13 @@ static int mq_event(void *ctx, void *data,unsigned long data_sz)
 int main(int argc, char **argv)
 {
 	struct ring_buffer *rb = NULL;
+	struct bpf_map *cs_ctrl_map = NULL;
+	struct bpf_map *sar_ctrl_map = NULL;
+	struct bpf_map *sc_ctrl_map = NULL;
+	struct bpf_map *preempt_ctrl_map = NULL;
+	struct bpf_map *schedule_ctrl_map = NULL;
+	struct bpf_map *mq_ctrl_map = NULL;
+	int key = 0;
 	int err;
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
@@ -645,6 +712,19 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Failed to load and verify BPF skeleton\n");
 			goto cs_delay_cleanup;
 		}
+
+		err = common_pin_map(&cs_ctrl_map,cs_skel->obj,"cs_ctrl_map",cs_ctrl_path);
+		if(err < 0){
+			goto cs_delay_cleanup;
+		}
+		csmap_fd = bpf_map__fd(cs_ctrl_map);
+		struct cs_ctrl init_value = {false,CS_WACTHER};
+		err = bpf_map_update_elem(csmap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto cs_delay_cleanup;
+		}
+
 		/* Attach tracepoints */
 		err = cs_delay_bpf__attach(cs_skel);
 		if (err)
@@ -671,6 +751,17 @@ int main(int argc, char **argv)
 			goto preempt_cleanup;
 		}
 
+		err = common_pin_map(&preempt_ctrl_map,preempt_skel->obj,"preempt_ctrl_map",preempt_ctrl_path);
+		if(err < 0){
+			goto preempt_cleanup;
+		}
+		preemptmap_fd = bpf_map__fd(preempt_ctrl_map);
+		struct preempt_ctrl init_value = {false,PREEMPT_WACTHER};
+		err = bpf_map_update_elem(preemptmap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto preempt_cleanup;
+		}
 		err = preempt_bpf__attach(preempt_skel);
 		if (err) {
 			fprintf(stderr, "Failed to attach BPF skeleton\n");
@@ -698,6 +789,17 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Failed to load and verify BPF skeleton\n");
 			goto sc_delay_cleanup;
 		}
+		err = common_pin_map(&sc_ctrl_map,sc_skel->obj,"sc_ctrl_map",sc_ctrl_path);
+		if(err < 0){
+			goto sc_delay_cleanup;
+		}
+		scmap_fd = bpf_map__fd(sc_ctrl_map);
+		struct sc_ctrl init_value = {false,SC_WACTHER};
+		err = bpf_map_update_elem(scmap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto sc_delay_cleanup;
+		}
 		/* Attach tracepoints */
 		err = sc_delay_bpf__attach(sc_skel);
 		if (err)
@@ -705,13 +807,15 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Failed to attach BPF skeleton\n");
 			goto sc_delay_cleanup;
 		}
+		printf("%-8s   %-8s   %-15s %-15s\n","Time","Pid","syscall_id","delay/ms");
 		rb = ring_buffer__new(bpf_map__fd(sc_skel->maps.rb), syscall_delay_print, NULL, NULL);	//ring_buffer__new() API，允许在不使用额外选项数据结构下指定回调
 		if (!rb) {
 			err = -1;
 			fprintf(stderr, "Failed to create ring buffer\n");
 			goto sc_delay_cleanup;		
 		}
-	}else if(env.SCHEDULE_DELAY||env.MIN_US_SET){
+
+	}else if(env.SCHEDULE_DELAY){
 		sd_skel = schedule_delay_bpf__open();
 		if (!sd_skel) {
 			fprintf(stderr, "Failed to open and load BPF skeleton\n");
@@ -722,16 +826,22 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Failed to load and verify BPF skeleton\n");
 			goto schedule_cleanup;
 		}
+		err = common_pin_map(&schedule_ctrl_map,sd_skel->obj,"schedule_ctrl_map",schedule_ctrl_path);
+		if(err < 0){
+			goto schedule_cleanup;
+		}
+		schedulemap_fd = bpf_map__fd(schedule_ctrl_map);
+		struct schedule_ctrl init_value = {false,false,10000,SCHEDULE_WACTHER};
+
+		err = bpf_map_update_elem(schedulemap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto schedule_cleanup;
+		}
 		err = schedule_delay_bpf__attach(sd_skel);
 		if (err) {
 			fprintf(stderr, "Failed to attach BPF skeleton\n");
 			goto schedule_cleanup;
-		}
-		if(env.MIN_US_SET){
-			printf("调度延时大于%dms的进程:\n",env.MIN_US/1000);
-			printf("%s\n","pid        COMM                   schedule_delay/us");
-		}else{
-			printf("%-8s %s\n",  "  TIME ", "avg_delay/μs     max_delay/μs    max_proc_name    min_delay/μs   min_proc_name");
 		}
 	}else if (env.SAR){
 		/* Load and verify BPF application */
@@ -754,6 +864,18 @@ int main(int argc, char **argv)
 		err = open_and_attach_perf_event(env.freq, sar_skel->progs.tick_update, links);
 		if (err)
 			goto sar_cleanup;
+
+		err = common_pin_map(&sar_ctrl_map,sar_skel->obj,"sar_ctrl_map",sar_ctrl_path);
+		if(err < 0){
+			goto sar_cleanup;
+		}
+		sarmap_fd = bpf_map__fd(sar_ctrl_map);
+		struct sar_ctrl init_value = {false,SAR_WACTHER};
+		err = bpf_map_update_elem(sarmap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto sar_cleanup;
+		}
 
 		err = sar_bpf__attach(sar_skel);
 		if (err)
@@ -779,6 +901,19 @@ int main(int argc, char **argv)
 			fprintf(stderr, "Failed to load and verify BPF skeleton\n");
 			goto mq_delay_cleanup;
 		}
+
+		err = common_pin_map(&mq_ctrl_map,mq_skel->obj,"mq_ctrl_map",mq_ctrl_path);
+		if(err < 0){
+			goto mq_delay_cleanup;
+		}
+		mqmap_fd = bpf_map__fd(mq_ctrl_map);
+		struct mq_ctrl init_value = {false,MQ_WACTHER};
+		err = bpf_map_update_elem(mqmap_fd, &key, &init_value, 0);
+		if(err < 0){
+			fprintf(stderr, "Failed to update elem\n");
+			goto mq_delay_cleanup;
+		}
+
 		/* Attach tracepoints */
 		err = mq_delay_bpf__attach(mq_skel);
 		if (err)
@@ -831,11 +966,11 @@ int main(int argc, char **argv)
 				printf("Error polling perf buffer: %d\n", err);
 				break;
 			}
-			time_t now = time(NULL);// 获取当前时间
-			struct tm *localTime = localtime(&now);// 将时间转换为本地时间结构
-			printf("\n\nTime: %02d:%02d:%02d\n",localTime->tm_hour, localTime->tm_min, localTime->tm_sec);
-			printf("----------------------------------------------------------------------------------------------------------\n");
-			sleep(1);			
+			// time_t now = time(NULL);// 获取当前时间
+			// struct tm *localTime = localtime(&now);// 将时间转换为本地时间结构
+			// printf("\n\nTime: %02d:%02d:%02d\n",localTime->tm_hour, localTime->tm_min, localTime->tm_sec);
+			// printf("----------------------------------------------------------------------------------------------------------\n");
+			// sleep(1);			
 		}
 		else if (env.PREEMPT) {
 			err = ring_buffer__poll(rb, 100 /* timeout, ms */);
@@ -861,7 +996,7 @@ int main(int argc, char **argv)
 			sum_preemptTime = 0;
 			sleep(2);
 		}
-		else if (env.SCHEDULE_DELAY||env.MIN_US_SET){
+		else if (env.SCHEDULE_DELAY){
 			err = schedule_print();
 			if (err == -EINTR) {
 				err = 0;
@@ -892,29 +1027,35 @@ int main(int argc, char **argv)
 	}
 
 cs_delay_cleanup:
+	bpf_map__unpin(cs_ctrl_map, cs_ctrl_path);
 	ring_buffer__free(rb);
 	cs_delay_bpf__destroy(cs_skel);
 	return err < 0 ? -err : 0;
 
 sar_cleanup:
+	bpf_map__unpin(sar_ctrl_map, sar_ctrl_path);
 	sar_bpf__destroy(sar_skel);
 	return err < 0 ? -err : 0;
 
 sc_delay_cleanup:
+	bpf_map__unpin(sc_ctrl_map, sc_ctrl_path);
 	ring_buffer__free(rb);
 	sc_delay_bpf__destroy(sc_skel);
 	return err < 0 ? -err : 0;
 
 preempt_cleanup:
+	bpf_map__unpin(preempt_ctrl_map, preempt_ctrl_path);	
 	ring_buffer__free(rb);
 	preempt_bpf__destroy(preempt_skel);
 	return err < 0 ? -err : 0;
 
 schedule_cleanup:
+	bpf_map__unpin(schedule_ctrl_map, schedule_ctrl_path);
 	schedule_delay_bpf__destroy(sd_skel);
 	return err < 0 ? -err : 0;
 
 mq_delay_cleanup:
+	bpf_map__unpin(mq_ctrl_map, mq_ctrl_path);
 	ring_buffer__free(rb);
 	mq_delay_bpf__destroy(mq_skel);
 	return err < 0 ? -err : 0;

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher.h
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 //
 // author: albert_xuu@163.com zhangxy1016304@163.com zhangziheng0525@163.com
+#ifndef CPU_WATCHER_H
+#define CPU_WATCHER_H
 
 #include <asm/types.h>
 #include <linux/version.h>
@@ -218,3 +220,40 @@ struct idleStruct {
 	unsigned int state;
 	unsigned int cpu_id;
 };
+
+/*----------------------------------------------*/
+/*          控制板块                            */
+/*----------------------------------------------*/
+struct sar_ctrl{
+	bool sar_func;
+	int prev_watcher;
+};
+
+struct cs_ctrl{
+	bool cs_func;
+	int prev_watcher;
+};
+
+struct sc_ctrl{
+	bool sc_func;
+	int prev_watcher;
+};
+
+struct preempt_ctrl{
+	bool preempt_func;
+	int prev_watcher;
+};
+
+struct schedule_ctrl{
+	bool schedule_func;
+	bool min_us_set;
+	int min_us;
+	int prev_watcher;
+};
+
+struct mq_ctrl{
+	bool mq_func;
+	int prev_watcher;
+};
+
+#endif // CPU_WATCHER_H

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher.h
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher.h
@@ -134,8 +134,14 @@ struct sum_schedule {
 	unsigned long long sum_delay;
 	unsigned long long max_delay;
 	unsigned long long min_delay;
-    int pid_max;
-	int pid_min;
+    char proc_name_max[TASK_COMM_LEN];
+	char proc_name_min[TASK_COMM_LEN];
+};
+
+struct proc_schedule {
+	int pid;
+	unsigned long long delay;
+	char proc_name[TASK_COMM_LEN];
 };
 
 /*----------------------------------------------*/

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher_helper.h
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/include/cpu_watcher_helper.h
@@ -1,0 +1,202 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: albert_xuu@163.com zhangxy1016304@163.com zhangziheng0525@163.com
+#ifndef CPU_WATCHER_HELPER_H
+#define CPU_WATCHER_HELPER_H
+
+#include <stdio.h>
+#include "cpu_watcher.h"
+
+#define SAR_WACTHER 10
+#define CS_WACTHER 20
+#define SC_WACTHER 30
+#define PREEMPT_WACTHER 40
+#define SCHEDULE_WACTHER 50
+#define MQ_WACTHER 60
+
+/*----------------------------------------------*/
+/*          ewma算法                            */
+/*----------------------------------------------*/
+//滑动窗口周期，用于计算alpha
+#define CYCLE 10
+//阈值容错空间；
+#define TOLERANCE 1.0
+struct ewma_info{
+	double previousEWMA;
+	int count;
+	int cycle;//cycle是滑动窗口周期大小
+};
+
+double calculateEWMA(double previousEWMA, double dataPoint, double alpha) {
+    return alpha * dataPoint + (1 - alpha) * previousEWMA;//当前时间点的ewma
+}
+
+bool dynamic_filter(struct ewma_info *ewma_syscall_delay, double dataPoint) {
+    double alpha,threshold;
+	if(ewma_syscall_delay->cycle==0) alpha = 2.0 /(CYCLE + 1); // 计算 alpha
+	else alpha = 2.0 /(ewma_syscall_delay->cycle + 1); 
+
+	if(ewma_syscall_delay->previousEWMA == 0) {//初始化ewma算法，则赋值previousEWMA = dataPoint 并打印
+		ewma_syscall_delay->previousEWMA = dataPoint;
+		return 1;
+	}
+	if(ewma_syscall_delay->count <30){
+		ewma_syscall_delay->previousEWMA = calculateEWMA(ewma_syscall_delay->previousEWMA,dataPoint,alpha);//计算
+		return 1;
+	}
+	else{
+		ewma_syscall_delay->previousEWMA = calculateEWMA(ewma_syscall_delay->previousEWMA,dataPoint,alpha);//计算
+		threshold = ewma_syscall_delay->previousEWMA * TOLERANCE;
+		if(dataPoint >= threshold) return 1;
+	}
+    return 0;
+}
+
+
+const char *sar_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/sar_ctrl_map";
+const char *cs_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/cs_ctrl_map";
+const char *sc_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/sc_ctrl_map";
+const char *preempt_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/preempt_ctrl_map";
+const char *schedule_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/schedule_ctrl_map";
+const char *mq_ctrl_path =  "/sys/fs/bpf/cpu_watcher_map/mq_ctrl_map";
+
+int common_pin_map(struct bpf_map **bpf_map, const struct bpf_object *obj, const char *map_name, const char *ctrl_path)
+{
+    int ret;
+    
+    *bpf_map = bpf_object__find_map_by_name(obj, map_name);
+    if (!*bpf_map) {
+        fprintf(stderr, "Failed to find BPF map\n");
+        return -1;
+    }
+    // 用于防止上次没有成功 unpin 掉这个 map
+    bpf_map__unpin(*bpf_map, ctrl_path);
+    ret = bpf_map__pin(*bpf_map, ctrl_path);
+    if (ret){
+        fprintf(stderr, "Failed to pin BPF map\n");
+        return -1;
+    }
+	
+    return 0;
+}
+
+int update_sar_ctrl_map(struct sar_ctrl sar_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(sar_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open sar_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&sar_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update sar_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+
+int update_cs_ctrl_map(struct cs_ctrl cs_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(cs_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open cs_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&cs_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update cs_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+
+int update_sc_ctrl_map(struct sc_ctrl sc_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(sc_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open sc_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&sc_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update sc_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+
+int update_preempt_ctrl_map(struct preempt_ctrl preempt_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(preempt_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open preempt_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&preempt_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update preempt_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+
+int update_schedule_ctrl_map(struct schedule_ctrl schedule_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(schedule_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open schedule_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&schedule_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update schedule_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+
+int update_mq_ctrl_map(struct mq_ctrl mq_ctrl){
+	int err,key = 0;
+	int srcmap_fd;
+	
+	srcmap_fd = bpf_obj_get(mq_ctrl_path);
+    if (srcmap_fd < 0) {
+        fprintf(stderr,"Failed to open mq_ctrl_map file\n");
+        return srcmap_fd;
+    }
+    err = bpf_map_update_elem(srcmap_fd,&key,&mq_ctrl, 0);
+    if(err < 0){
+        fprintf(stderr, "Failed to update mq_ctrl_map elem\n");
+        return err;
+    }
+
+    return 0;
+}
+#endif // CPU_WATCHER_HELPER_H

--- a/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/test/test_cpuwatcher.c
+++ b/eBPF_Supermarket/CPU_Subsystem/cpu_watcher/test/test_cpuwatcher.c
@@ -174,7 +174,9 @@ int main(int argc, char **argv){
     }
 
     if(env.preempt_test){
-    /*preempt_delay的测试代码*/
+         printf("PREEMPT_TEST----------------------------------------------\n");
+        //PREEMPT功能测试逻辑：无限循环的线程函数，不断调用 sched_yield() 来放弃 CPU 使用权，模拟高调度负载。
+         start_schedule_stress_test(10); // 创建10个线程进行调度压力测试
     }
 
     if(env.schedule_test){
@@ -186,7 +188,6 @@ int main(int argc, char **argv){
         printf("执行指令 sysbench --threads=32 --time=10 cpu run\n");
         execve("/usr/bin/sysbench", argvv, envp);
         perror("execve");
-        
         printf("\n");
     }
 


### PR DESCRIPTION
1.在bcc中有runqslower工具，可以通过参数控制，打印出来哪些进程的调度延迟超过了特定的阈值。
该pr通过选项e为调度时延功能设置阈值，输出超过指定调度时延的进程。
2.2024 607：增加controller功能，可实现动态更改策略。

./cpu_watcher -e 5000输出：
![微信图片_20240531155356](https://github.com/linuxkerneltravel/lmp/assets/145555693/0b7a88f7-7937-46ed-a92c-d4a48c9cf813)

![屏幕截图 2024-06-07 143238](https://github.com/linuxkerneltravel/lmp/assets/145555693/72d84ee9-3061-4c36-be56-707d8538244f)
