### PR TITLE
netwatcher：update README and capture Mysql information

### DIFF
--- a/.github/workflows/ebpf_net_watcher.yml
+++ b/.github/workflows/ebpf_net_watcher.yml
@@ -46,4 +46,6 @@ jobs:
           sudo timeout -s SIGINT 5 ./netwatcher -k -T || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
           sudo timeout -s SIGINT 5 ./netwatcher -I || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
           sudo timeout -s SIGINT 5 ./netwatcher -S || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -D || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -M || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
         timeout-minutes: 5

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -151,6 +151,11 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 256 * 1024);
+} mysql_rb SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
 } kfree_rb SEC(".maps");
 
 struct {
@@ -224,12 +229,19 @@ struct {
 	__type(value, __u64);
 } tcp_state SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 256*1024);
+	__type(key, __u32);
+	__type(value, __u64);
+} mysql_time SEC(".maps");
+
 const volatile int filter_dport = 0;
 const volatile int filter_sport = 0;
 const volatile int all_conn = 0, err_packet = 0, extra_conn_info = 0,
                    layer_time = 0, http_info = 0, retrans_info = 0, udp_info =0,net_filter = 0,
-                   drop_reason = 0,icmp_info = 0 ,tcp_info = 0 ,dns_info = 0 ,stack_info = 0;
-
+                   drop_reason = 0,icmp_info = 0 ,tcp_info = 0 ,dns_info = 0 ,stack_info = 0,mysql_info = 0;
+                 
 /* help macro */
 
 #define FILTER                                          \

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/mysql.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/mysql.bpf.h
@@ -1,0 +1,79 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: blown.away@qq.com
+// mysql
+
+#include "common.bpf.h"
+#include "mysql_helper.bpf.h"
+static __always_inline int __handle_mysql_start(struct pt_regs *ctx) {
+    // dispatch_command(THD *thd, const COM_DATA *com_data, enum
+    char comm[16];
+    enum enum_server_command command = PT_REGS_PARM3(ctx);
+    union COM_DATA *com_data = (union COM_DATA *)PT_REGS_PARM2(ctx);
+
+    pid_t pid = bpf_get_current_pid_tgid() >> 32;
+    void *thd = (void *)PT_REGS_PARM1(ctx);
+    char *sql;
+    u32 size = 0;
+
+    if (command != COM_QUERY) {
+        return 0;
+    }
+
+    u64 start_time = bpf_ktime_get_ns()/1000;
+    bpf_map_update_elem(&mysql_time, &pid, &start_time, BPF_ANY);
+
+    struct mysql_query *message =
+        bpf_ringbuf_reserve(&mysql_rb, sizeof(*message), 0);
+    if (!message) {
+        return 0;
+    }
+
+    bpf_probe_read(&message->size, sizeof(message->size),
+                   &com_data->com_query.length);
+    bpf_probe_read_str(&sql, sizeof(sql), &com_data->com_query.query);
+    bpf_probe_read_str(&message->msql, sizeof(message->msql), sql);
+    bpf_printk("%s",sql);
+
+    message->pid = pid;
+    bpf_get_current_comm(&message->comm, sizeof(comm));
+
+    bpf_ringbuf_submit(message, 0);
+    return 0;
+}
+
+static __always_inline int __handle_mysql_end(struct pt_regs *ctx) {
+
+    pid_t pid = bpf_get_current_pid_tgid() >> 32;
+    u64 *start_time_ptr, duration;
+    u64 end_time = bpf_ktime_get_ns()/1000;
+    start_time_ptr = bpf_map_lookup_elem(&mysql_time, &pid);
+    if (!start_time_ptr) {
+        return 0;
+    }
+
+    duration = end_time - *start_time_ptr;
+    struct mysql_query *message =
+        bpf_ringbuf_reserve(&mysql_rb, sizeof(*message), 0);
+    if (!message) {
+        return 0;
+    }
+
+    message->duratime = duration;
+
+    bpf_ringbuf_submit(message, 0);
+    bpf_map_delete_elem(&mysql_time, &pid);
+    return 0;
+}

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/mysql_helper.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/mysql_helper.bpf.h
@@ -1,0 +1,171 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: blown.away@qq.com
+//
+// netwatcher libbpf 内核<->用户 传递信息相关结构体
+
+#ifndef __MYSQL_HELPER_BPF_H
+#define __MYSQL_HELPER_BPF_H
+
+#include "netwatcher.h"
+#include "vmlinux.h"
+#include <asm-generic/errno.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <string.h>
+
+enum enum_server_command {
+    COM_SLEEP,
+    COM_QUIT,
+    COM_INIT_DB,
+    COM_QUERY,
+    COM_FIELD_LIST,
+    COM_CREATE_DB,
+    COM_DROP_DB,
+    COM_REFRESH,
+    COM_SHUTDOWN,
+    COM_STATISTICS,
+    COM_PROCESS_INFO,
+    COM_CONNECT,
+    COM_PROCESS_KILL,
+    COM_DEBUG,
+    COM_PING,
+    COM_TIME,
+    COM_DELAYED_INSERT,
+    COM_CHANGE_USER,
+    COM_BINLOG_DUMP,
+    COM_TABLE_DUMP,
+    COM_CONNECT_OUT,
+    COM_REGISTER_SLAVE,
+    COM_STMT_PREPARE,
+    COM_STMT_EXECUTE,
+    COM_STMT_SEND_LONG_DATA,
+    COM_STMT_CLOSE,
+    COM_STMT_RESET,
+    COM_SET_OPTION,
+    COM_STMT_FETCH,
+    COM_DAEMON,
+    COM_BINLOG_DUMP_GTID,
+    COM_RESET_CONNECTION,
+    /* don't forget to update const char *command_name[] in sql_parse.cc */
+    /* Must be last */
+    COM_END
+};
+
+typedef struct st_com_init_db_data {
+    const char *db_name;
+    unsigned long length;
+} COM_INIT_DB_DATA;
+
+#define MYSQL_SHUTDOWN_KILLABLE_CONNECT (unsigned char)(1 << 0)
+#define MYSQL_SHUTDOWN_KILLABLE_TRANS (unsigned char)(1 << 1)
+#define MYSQL_SHUTDOWN_KILLABLE_LOCK_TABLE (unsigned char)(1 << 2)
+#define MYSQL_SHUTDOWN_KILLABLE_UPDATE (unsigned char)(1 << 3)
+
+#define LOCK_MODE_MASK 0xFUL
+#define LOCK_TYPE_MASK 0xF0UL
+
+enum mysql_enum_shutdown_level {
+    SHUTDOWN_DEFAULT = 0,
+    SHUTDOWN_WAIT_CONNECTIONS = MYSQL_SHUTDOWN_KILLABLE_CONNECT,
+    SHUTDOWN_WAIT_TRANSACTIONS = MYSQL_SHUTDOWN_KILLABLE_TRANS,
+    SHUTDOWN_WAIT_UPDATES = MYSQL_SHUTDOWN_KILLABLE_UPDATE,
+    SHUTDOWN_WAIT_ALL_BUFFERS = (MYSQL_SHUTDOWN_KILLABLE_UPDATE << 1),
+    SHUTDOWN_WAIT_CRITICAL_BUFFERS = (MYSQL_SHUTDOWN_KILLABLE_UPDATE << 1) + 1,
+    KILL_QUERY = 254,
+    KILL_CONNECTION = 255
+};
+
+typedef struct st_com_refresh_data {
+    unsigned char options;
+} COM_REFRESH_DATA;
+
+typedef struct st_com_shutdown_data {
+    enum mysql_enum_shutdown_level level;
+} COM_SHUTDOWN_DATA;
+
+typedef struct st_com_kill_data {
+    unsigned long id;
+} COM_KILL_DATA;
+
+typedef struct st_com_set_option_data {
+    unsigned int opt_command;
+} COM_SET_OPTION_DATA;
+
+typedef struct st_com_stmt_execute_data {
+    unsigned long stmt_id;
+    unsigned long flags;
+    unsigned char *params;
+    unsigned long params_length;
+} COM_STMT_EXECUTE_DATA;
+
+typedef struct st_com_stmt_fetch_data {
+    unsigned long stmt_id;
+    unsigned long num_rows;
+} COM_STMT_FETCH_DATA;
+
+typedef struct st_com_stmt_send_long_data_data {
+    unsigned long stmt_id;
+    unsigned int param_number;
+    unsigned char *longdata;
+    unsigned long length;
+} COM_STMT_SEND_LONG_DATA_DATA;
+
+typedef struct st_com_stmt_prepare_data {
+    const char *query;
+    unsigned int length;
+} COM_STMT_PREPARE_DATA;
+
+typedef struct st_stmt_close_data {
+    unsigned int stmt_id;
+} COM_STMT_CLOSE_DATA;
+
+typedef struct st_com_stmt_reset_data {
+    unsigned int stmt_id;
+} COM_STMT_RESET_DATA;
+
+typedef struct st_com_query_data {
+    const char *query;
+    unsigned int length;
+} COM_QUERY_DATA;
+
+typedef struct st_com_field_list_data {
+    unsigned char *table_name;
+    unsigned int table_name_length;
+    const unsigned char *query;
+    unsigned int query_length;
+} COM_FIELD_LIST_DATA;
+
+union COM_DATA {
+    COM_INIT_DB_DATA com_init_db;
+    COM_REFRESH_DATA com_refresh;
+    COM_SHUTDOWN_DATA com_shutdown;
+    COM_KILL_DATA com_kill;
+    COM_SET_OPTION_DATA com_set_option;
+    COM_STMT_EXECUTE_DATA com_stmt_execute;
+    COM_STMT_FETCH_DATA com_stmt_fetch;
+    COM_STMT_SEND_LONG_DATA_DATA com_stmt_send_long_data;
+    COM_STMT_PREPARE_DATA com_stmt_prepare;
+    COM_STMT_CLOSE_DATA com_stmt_close;
+    COM_STMT_RESET_DATA com_stmt_reset;
+    COM_QUERY_DATA com_query;
+    COM_FIELD_LIST_DATA com_field_list;
+};
+
+/* help functions end */
+
+#endif

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
@@ -159,12 +159,21 @@ struct dns_information {
 #define MAX_STACK_DEPTH 128
 typedef u64 stack_trace_t[MAX_STACK_DEPTH];
 struct stacktrace_event {
-	u32 pid;
-	u32 cpu_id;
-	char comm[16];
-	signed int kstack_sz;
-	signed int ustack_sz;
-	stack_trace_t kstack;
-	stack_trace_t ustack;
+    u32 pid;
+    u32 cpu_id;
+    char comm[16];
+    signed int kstack_sz;
+    signed int ustack_sz;
+    stack_trace_t kstack;
+    stack_trace_t ustack;
 };
+
+typedef struct mysql_query {
+    int pid;
+    char comm[20];
+    u32 size;
+    char msql[256];
+    u64 duratime;
+} mysql_query;
+
 #endif /* __NETWATCHER_H */


### PR DESCRIPTION
更新READMD文件信息、uprobe实现Mysql数据库的监测、信息为进程pid、进程名、Sql语句、Sql语句字节大小、Sql执行耗时。
![1e0b2451489b417ed87fc629fb3a30c](https://github.com/linuxkerneltravel/lmp/assets/147615158/eda038c5-7e8f-4072-a1be-4dd6779b3881)
