### PR TITLE
kvm_watcher:兼容可视化数据格式要求并修改可视化文档

### DIFF
--- a/eBPF_Supermarket/kvm_watcher/docs/Visualization_conf.md
+++ b/eBPF_Supermarket/kvm_watcher/docs/Visualization_conf.md
@@ -110,6 +110,7 @@ make start_service
 #进入lmp/eBPF_Visualization/eBPF_prometheus目录，执行以下操作
 #开启ebpf程序，并且向8090端口推送ebpf程序采集的数据，发送给prometheus服务端
 #这里以监测vcpu调度的数据来举例：
+#目前-e、-o、-i、-f -m功能的数据格式已经适配了可视化工具，请读者使用以上四种功能的数据来进行可视化展示
 ./data-visual collect lmp/eBPF_Supermarket/kvm_watcher/kvm_watcher -o -p [进程号]
 ```
 


### PR DESCRIPTION
通过输入-s参数可以将mmio页面错误监测功能和irq监测功能的输出数据格式兼容prometheus的数据格式，若不加-s参数，则是项目之前定义的完整输出格式。#552
不加-s参数之前:
1.mmio：
![image](https://github.com/linuxkerneltravel/lmp/assets/78297703/eecb97dc-57ea-455a-a467-5a0cd408e147)
2.irq：
![image](https://github.com/linuxkerneltravel/lmp/assets/78297703/8f3c61bb-9ba9-4883-ba9a-3362aff1f74b)
加入-s参数之后:
1.mmio：
![image](https://github.com/linuxkerneltravel/lmp/assets/78297703/b3ac7677-8bda-417e-b461-6c7d1a431568)

2.irq：
![image](https://github.com/linuxkerneltravel/lmp/assets/78297703/16a4a1a8-0503-4c87-9714-fa07af3e2f3f)