### PR TITLE
netwatcher：Sql time-consuming threshold and Dns request response number

### DIFF
--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -102,6 +102,11 @@ struct dns_query {
     char data[64];// 可变长度数据（域名+类型+类）
 };
 
+struct dns{
+    u32 saddr;       
+    u32 daddr;  
+};
+
 // 操作BPF映射的一个辅助函数
 static __always_inline void * //__always_inline强制内联
 bpf_map_lookup_or_try_init(void *map, const void *key, const void *init) {
@@ -242,6 +247,20 @@ struct {
     __type(key,__u32);
     __type(value,__u64);
 } sql_count SEC(".maps");
+//dns计数根据每个saddr、daddr
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key,struct dns);
+    __type(value,__u64);
+} dns_request_count SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key,struct dns);
+    __type(value,__u64);
+} dns_response_count SEC(".maps");
 
 const volatile int filter_dport = 0;
 const volatile int filter_sport = 0;

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -233,6 +233,7 @@ struct {
 	__type(key, struct sock *);
 	__type(value, __u64);
 } tcp_state SEC(".maps");
+
 //sql 耗时
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -240,6 +241,7 @@ struct {
 	__type(key, __u32);
 	__type(value, __u64);
 } mysql_time SEC(".maps");
+
 //sql请求数
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -247,6 +249,7 @@ struct {
     __type(key,__u32);
     __type(value,__u64);
 } sql_count SEC(".maps");
+
 //dns计数根据每个saddr、daddr
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -228,13 +228,20 @@ struct {
 	__type(key, struct sock *);
 	__type(value, __u64);
 } tcp_state SEC(".maps");
-
+//sql 耗时
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 256*1024);
 	__type(key, __u32);
 	__type(value, __u64);
 } mysql_time SEC(".maps");
+//sql请求数
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key,__u32);
+    __type(value,__u64);
+} sql_count SEC(".maps");
 
 const volatile int filter_dport = 0;
 const volatile int filter_sport = 0;

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
@@ -74,11 +74,11 @@ static const struct argp_option opts[] = {
     {"dns", 'D', 0, 0,
      "set to trace dns information info include Id 事务ID、Flags 标志字段、Qd "
      "问题部分计数、An 应答记录计数、Ns 授权记录计数、Ar 附加记录计数、Qr "
-     "域名、rx 收发包 "},
+     "域名、rx 收发包 、Qc请求数、Sc响应数"},
     {"stack", 'A', 0, 0, "set to trace of stack "},
     {"mysql", 'M', 0, 0,
      "set to trace mysql information info include Pid 进程id、Comm "
-     "进程名、Size sql语句字节大小、Sql 语句"},
+     "进程名、Size sql语句字节大小、Sql 语句、Duration Sql耗时、Request Sql请求数"},
     {}};
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state) {

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
@@ -43,7 +43,8 @@ static int sport = 0, dport = 0; // for filter
 static int all_conn = 0, err_packet = 0, extra_conn_info = 0, layer_time = 0,
            http_info = 0, retrans_info = 0, udp_info = 0, net_filter = 0,
            drop_reason = 0, addr_to_func = 0, icmp_info = 0, tcp_info = 0,
-           time_load = 0, dns_info = 0, stack_info = 0, mysql_info = 0,count_info = 0; // flag
+           time_load = 0, dns_info = 0, stack_info = 0, mysql_info = 0,
+           count_info = 0; // flag
 
 static const char *tcp_states[] = {
     [1] = "ESTABLISHED", [2] = "SYN_SENT",   [3] = "SYN_RECV",
@@ -79,7 +80,8 @@ static const struct argp_option opts[] = {
      "set to trace mysql information info include Pid 进程id、Comm "
      "进程名、Size sql语句字节大小、Sql 语句、Duration Sql耗时、Request "
      "Sql请求数"},
-    {"count", 'C', "NUMBER", 0, "specify the time to count the number of requests"}, 
+    {"count", 'C', "NUMBER", 0,
+     "specify the time to count the number of requests"},
     {}};
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state) {
@@ -140,7 +142,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state) {
         mysql_info = 1;
         break;
     case 'C':
-        count_info =strtoul(arg,&end, 10);
+        count_info = strtoul(arg, &end, 10);
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -257,7 +259,6 @@ static const char binary_path[] = "/usr/sbin/mysqld";
     __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, false)
 #define ATTACH_URETPROBE_CHECKED(skel, sym_name, prog_name)                    \
     __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, true)
-static time_t last_check_time = 0;
 struct SymbolEntry symbols[300000];
 int num_symbols = 0;
 // 定义快表
@@ -1042,6 +1043,7 @@ static int print_icmptime(void *ctx, void *packet_info, size_t size) {
     printf("\n");
     return 0;
 }
+
 // 从DNS数据包中提取并打印域名
 static void print_domain_name(const unsigned char *data, char *output) {
     const unsigned char *next = data;
@@ -1060,15 +1062,6 @@ static void print_domain_name(const unsigned char *data, char *output) {
         }
     }
     output[pos] = '\0'; // 确保字符串正确结束
-}
-
-bool check_time()
-{
-    if(time(NULL)-last_check_time >= count_info){
-        last_check_time=time(NULL);
-        return true;
-    }
-    return false;
 }
 
 static int print_dns(void *ctx, void *packet_info, size_t size) {
@@ -1101,23 +1094,24 @@ static mysql_query last_query;
 
 static int print_mysql(void *ctx, void *packet_info, size_t size) {
     if (!mysql_info) {
-        return 0; 
+        return 0;
     }
 
     const mysql_query *pack_info = packet_info;
     if (pack_info->duratime == 0) {
-     
+
         memcpy(&last_query, pack_info, sizeof(mysql_query));
     } else {
-   
+
         printf("%-20d %-20d %-20s %-20u %-40s", last_query.pid, last_query.tid,
                last_query.comm, last_query.size, last_query.msql);
-        // 当 duratime 大于 count_info 时，才打印 duratime 
+        // 当 duratime 大于 count_info 时，才打印 duratime
         if (pack_info->duratime > count_info) {
             printf("%-21llu", pack_info->duratime);
-        }else {
+        } else {
             printf("%-21s", "");
         }
+
         printf("%-20d\n", pack_info->count);
         memset(&last_query, 0, sizeof(mysql_query));
     }

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
@@ -170,10 +170,12 @@ struct stacktrace_event {
 
 typedef struct mysql_query {
     int pid;
+    int tid;
     char comm[20];
     u32 size;
     char msql[256];
     u64 duratime;
+    int count;
 } mysql_query;
 
 #endif /* __NETWATCHER_H */

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
@@ -155,6 +155,8 @@ struct dns_information {
     u16 arcount;
     char data[64];
     int rx;
+    int response_count;
+    int request_count;
 };
 #define MAX_STACK_DEPTH 128
 typedef u64 stack_trace_t[MAX_STACK_DEPTH];

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/udp.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/udp.bpf.h
@@ -123,7 +123,8 @@ static __always_inline int __ip_send_skb(struct sk_buff *skb) {
 static __always_inline int process_dns_packet(struct sk_buff *skb, int rx) {
     if (skb == NULL)
         return 0;
-
+    u16 QR_flags;
+    u64 *count_ptr, response_count = 0, request_count = 0;
     struct sock *sk = BPF_CORE_READ(skb, sk);
     struct packet_tuple pkt_tuple = {
         .saddr = BPF_CORE_READ(sk, __sk_common.skc_rcv_saddr),
@@ -131,6 +132,8 @@ static __always_inline int process_dns_packet(struct sk_buff *skb, int rx) {
         .sport = BPF_CORE_READ(sk, __sk_common.skc_num),
         .dport = __bpf_ntohs(BPF_CORE_READ(sk, __sk_common.skc_dport)),
         .tran_flag = UDP};
+    // 使用saddr、daddr作为key
+    struct dns key = {.saddr = pkt_tuple.saddr, .daddr = pkt_tuple.daddr};
 
     if ((pkt_tuple.sport != 53) && (pkt_tuple.dport != 53))
         return 0;
@@ -151,7 +154,36 @@ static __always_inline int process_dns_packet(struct sk_buff *skb, int rx) {
     bpf_probe_read_kernel(message->data, sizeof(message->data),
                           BPF_CORE_READ(skb, head) + dns_offset +
                               sizeof(struct dns_header));
-
+    QR_flags = __bpf_ntohs(query.header.flags);
+    // 响应 QR=1
+    if (QR_flags & 0x8000) {
+        count_ptr = bpf_map_lookup_elem(&dns_response_count, &key);
+        if (count_ptr) {
+            response_count = *count_ptr + 1;
+        } else {
+            response_count = 1;
+        }
+        bpf_map_update_elem(&dns_response_count, &key, &response_count,
+                            BPF_ANY);
+        count_ptr = bpf_map_lookup_elem(&dns_request_count, &key);
+        if (count_ptr) {
+            request_count = *count_ptr;
+        }
+        //   bpf_printk("qr1=%d", response_count);
+    } else { // 请求 QR=0
+        count_ptr = bpf_map_lookup_elem(&dns_request_count, &key);
+        if (count_ptr) {
+            request_count = *count_ptr + 1;
+        } else {
+            request_count = 1;
+        }
+        bpf_map_update_elem(&dns_request_count, &key, &request_count, BPF_ANY);
+        count_ptr = bpf_map_lookup_elem(&dns_response_count, &key);
+        if (count_ptr) {
+            response_count = *count_ptr;
+        } 
+        // bpf_printk("qr2=%d", request_count);
+    }
     message->saddr = rx ? pkt_tuple.saddr : pkt_tuple.daddr;
     message->daddr = rx ? pkt_tuple.daddr : pkt_tuple.saddr;
     message->id = __bpf_ntohs(query.header.id);
@@ -160,6 +192,8 @@ static __always_inline int process_dns_packet(struct sk_buff *skb, int rx) {
     message->ancount = __bpf_ntohs(query.header.ancount);
     message->nscount = __bpf_ntohs(query.header.nscount);
     message->arcount = __bpf_ntohs(query.header.arcount);
+    message->request_count = request_count;
+    message->response_count = response_count;
     message->rx = rx;
 
     bpf_ringbuf_submit(message, 0);


### PR DESCRIPTION
-M -C 阈值数（微妙))                           增加sql耗时阈值、对超过输入的阈值显示耗时、没有超过阈值则不显示，根据tid去统计请求数
![4b31693dbfcf4d906976deb969739cb](https://github.com/linuxkerneltravel/lmp/assets/147615158/c7bef88d-a449-4a84-b4d4-0000514a76b5)
根据源地址和目的地址统计DNS请求数Qc、响应数Sc
![image](https://github.com/linuxkerneltravel/lmp/assets/147615158/3b1bfda0-218b-4e69-ad47-be2977b43fa2)
