### PR TITLE
netwatcher :更改uprobe适配判断、增添redis监控信息 (incomplete)

### DIFF
--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -269,7 +269,8 @@ const volatile int filter_dport = 0;
 const volatile int filter_sport = 0;
 const volatile int all_conn = 0, err_packet = 0, extra_conn_info = 0,
                    layer_time = 0, http_info = 0, retrans_info = 0, udp_info =0,net_filter = 0,
-                   drop_reason = 0,icmp_info = 0 ,tcp_info = 0 ,dns_info = 0 ,stack_info = 0,mysql_info = 0;
+                   drop_reason = 0,icmp_info = 0 ,tcp_info = 0 ,dns_info = 0 ,stack_info = 0,
+                   mysql_info = 0, redis_info;
                  
 /* help macro */
 

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/data/connects.log
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/data/connects.log
@@ -1,1 +1,0 @@
-connection{pid="214827",sock="0xffff944e0c3dda00",src="192.168.239.132:35422",dst="20.189.173.1:443",is_server="0",backlog="-",maxbacklog="-",cwnd="-",ssthresh="-",sndbuf="-",wmem_queued="-",rx_bytes="-",tx_bytes="-",srtt="-",duration="-",total_retrans="-",fast_retrans="-",timeout_retrans="-"}

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
@@ -30,6 +30,8 @@
 
 #include "mysql.bpf.h"
 
+#include "redis.bpf.h"
+
 #include "drop.bpf.h"
 
 // accecpt an TCP connection
@@ -330,4 +332,9 @@ int BPF_KPROBE(query__start) {
 SEC("uretprobe/_Z16dispatch_commandP3THDPK8COM_DATA19enum_server_command")
 int BPF_KPROBE(query__end){
     return __handle_mysql_end(ctx); 
+}
+
+SEC("uprobe/processCommand")
+int BPF_KPROBE(query__start_redis) { 
+    return __handle_redis_start(ctx); 
 }

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/packet.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/packet.bpf.h
@@ -393,12 +393,12 @@ int __tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
 
     // TX HTTP info
     if (http_info) {
-        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 1)
-            u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
-        #else
-            u8 *user_data = BPF_CORE_READ(msg, msg_iter.iov,iov_base);
-        #endif
-        //u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
+        // #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 1)
+        //     u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
+        // #else
+        //     u8 *user_data = BPF_CORE_READ(msg, msg_iter.iov,iov_base);
+        // #endif
+        u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
         tinfo = (struct ktime_info *)bpf_map_lookup_or_try_init(
             &timestamps, &pkt_tuple, &zero);
         if (tinfo == NULL) {

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/packet.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/packet.bpf.h
@@ -393,12 +393,12 @@ int __tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
 
     // TX HTTP info
     if (http_info) {
-        // #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 1)
-        //     u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
-        // #else
-        //     u8 *user_data = BPF_CORE_READ(msg, msg_iter.iov,iov_base);
-        // #endif
-        u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 1)
+            u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
+        #else
+            u8 *user_data = BPF_CORE_READ(msg, msg_iter.iov,iov_base);
+        #endif
+        //u8 *user_data = BPF_CORE_READ(msg, msg_iter.__iov, iov_base);
         tinfo = (struct ktime_info *)bpf_map_lookup_or_try_init(
             &timestamps, &pkt_tuple, &zero);
         if (tinfo == NULL) {

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/redis.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/redis.bpf.h
@@ -1,0 +1,47 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: blown.away@qq.com
+// mysql
+
+#include "common.bpf.h"
+#include "redis_helper.bpf.h"
+
+static __always_inline int __handle_redis_start(struct pt_regs *ctx) {
+    struct client *cli = (struct client *)PT_REGS_PARM1(ctx);
+    int argc;               
+    char name; 
+    int argv_len;          
+    bpf_probe_read(&argc, sizeof(argc), &cli->argc);
+    robj **arg0;
+    robj *arg1;
+    //unsigned type;
+    unsigned encoding;
+    unsigned lru; 
+    int refcount;
+    bpf_probe_read(&arg0, sizeof(arg0), &cli->argv);
+
+    // 读取 argv[0]，即第一个命令参数
+    bpf_probe_read(&arg1, sizeof(arg1), &arg0[1]);
+
+    // 读取 argv[0]->ptr 中的字符串
+    bpf_probe_read(&name, sizeof(name),&arg1->ptr);
+    bpf_probe_read(&argv_len, sizeof(argv_len), &cli->argv_len_sum);
+;
+    bpf_printk("%d %s %d",argc,name,argv_len);
+
+    pid_t pid = bpf_get_current_pid_tgid() >> 32;
+    return 0;
+}
+

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/redis_helper.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/redis_helper.bpf.h
@@ -32,7 +32,7 @@
 typedef struct redisObject {
     unsigned type:4;
     unsigned encoding:4;
-    unsigned lru:LRU_BITS; 
+    unsigned lru:24; 
     int refcount;
     void *ptr;
 } robj;

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/redis_helper.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/redis_helper.bpf.h
@@ -1,0 +1,55 @@
+// Copyright 2023 The LMP Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/linuxkerneltravel/lmp/blob/develop/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// author: blown.away@qq.com
+//
+// netwatcher libbpf 内核<->用户 传递信息相关结构体
+
+#ifndef __REDIS_HELPER_BPF_H
+#define __REDIS_HELPER_BPF_H
+
+#include "netwatcher.h"
+#include "vmlinux.h"
+#include <asm-generic/errno.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <string.h>
+
+#define LRU_BITS 24
+typedef struct redisObject {
+    unsigned type:4;
+    unsigned encoding:4;
+    unsigned lru:LRU_BITS; 
+    int refcount;
+    void *ptr;
+} robj;
+
+struct client {
+    u64 id;            /* Client incremental unique ID. */
+    u64 conn;
+    int resp;               /* RESP protocol version. Can be 2 or 3. */
+    u64 db;            /* Pointer to currently SELECTed DB. */
+    robj *name;             /* As set by CLIENT SETNAME. */
+    char* querybuf;           /* Buffer we use to accumulate client queries. */
+    unsigned long qb_pos;          /* The position we have read in querybuf. */
+    char* pending_querybuf;
+    unsigned long querybuf_peak;   /* Recent (100ms or more) peak of querybuf size. */
+    int argc;               /* Num of arguments of current command. */
+    robj **argv;            /* Arguments of current command. */
+    unsigned long argv_len_sum;           /* Size of argv array (may be more than argc) */
+};
+
+#endif


### PR DESCRIPTION
![88a7a4c8d14f4cd1723495375d48866](https://github.com/linuxkerneltravel/lmp/assets/93031728/dbc5b277-f507-4426-a41a-77e9473102a8)
目前有一点小问题需要解决 其结构为  
 ```
  int argc; 
  robj **argv;
  unsigned long argv_len_sum; 
```
目前能正确拉取 argc 与argv_len_sum，但不能拉取到argv中的命令名称
其结构为
```
typedef struct redisObject {
    unsigned type:4;
    unsigned encoding:4;
    unsigned lru:24; 
    int refcount;
    void *ptr;
} robj;
```