### PR TITLE
netwatcher:增加redis的延时信息

### DIFF
--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/common.bpf.h
@@ -161,6 +161,11 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 256 * 1024);
+} redis_rb SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
 } kfree_rb SEC(".maps");
 
 struct {
@@ -242,6 +247,14 @@ struct {
 	__type(value, __u64);
 } mysql_time SEC(".maps");
 
+//redis 耗时
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 256*1024);
+	__type(key, __u32);
+	__type(value, struct redis_query);
+} redis_time SEC(".maps");
+
 //sql请求数
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -270,7 +283,7 @@ const volatile int filter_sport = 0;
 const volatile int all_conn = 0, err_packet = 0, extra_conn_info = 0,
                    layer_time = 0, http_info = 0, retrans_info = 0, udp_info =0,net_filter = 0,
                    drop_reason = 0,icmp_info = 0 ,tcp_info = 0 ,dns_info = 0 ,stack_info = 0,
-                   mysql_info = 0, redis_info;
+                   mysql_info = 0, redis_info = 0;
                  
 /* help macro */
 

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
@@ -334,7 +334,11 @@ int BPF_KPROBE(query__end){
     return __handle_mysql_end(ctx); 
 }
 
-SEC("uprobe/processCommand")
+SEC("uprobe/call")
 int BPF_KPROBE(query__start_redis) { 
     return __handle_redis_start(ctx); 
+}
+SEC("uretprobe/call")
+int BPF_KPROBE(query__end_redis){
+    return __handle_redis_end(ctx); 
 }

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
@@ -566,6 +566,8 @@ static void set_disable_load(struct netwatcher_bpf *skel) {
                               mysql_info ? true : false);
     bpf_program__set_autoload(skel->progs.query__start_redis,
                               redis_info ? true : false);
+    bpf_program__set_autoload(skel->progs.query__end_redis,
+                              redis_info ? true : false);
 }
 
 static void print_header(enum MonitorMode mode) {
@@ -629,10 +631,10 @@ static void print_header(enum MonitorMode mode) {
         break;
     case MODE_REDIS:
         printf("==============================================================="
-               "====================MYSQL "
+               "====================REDIS "
                "INFORMATION===================================================="
                "============================\n");
-        printf("%-20s %-20s %-20s %-40s %-20s \n", "Pid", "Comm", "Size", "Sql",
+        printf("%-20s %-20s %-20s %-20s %-20s \n", "Pid", "Comm", "Size", "Redis",
                "duration/μs");
         break;
     case MODE_DEFAULT:
@@ -1135,6 +1137,20 @@ static int print_mysql(void *ctx, void *packet_info, size_t size) {
     }
     return 0;
 }
+static int print_redis(void *ctx, void *packet_info, size_t size) {
+    const struct redis_query *pack_info = packet_info;
+    int i=0;
+    char redis[64];
+    for(i=0;i<pack_info->argc;i++)
+    {   
+        strcat(redis, pack_info->redis[i]);
+        strcat(redis, " ");
+    }
+     printf("%-20d %-20s %-20d %-20s %-21llu\n", pack_info->pid,
+            pack_info->comm,pack_info->argc, redis,pack_info->duratime);
+    strcpy(redis,"");
+    return 0;
+}
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
                            va_list args) {
     return vfprintf(stderr, format, args);
@@ -1185,8 +1201,11 @@ int attach_uprobe_mysql(struct netwatcher_bpf *skel) {
 }
 int attach_uprobe_redis(struct netwatcher_bpf *skel) {
     ATTACH_UPROBE_CHECKED(
-        skel, processCommand,
+        skel, call,
         query__start_redis);
+    ATTACH_UPROBE_CHECKED(
+        skel, call,
+        query__end_redis);
     return 0;
 }
 int main(int argc, char **argv) {
@@ -1211,6 +1230,7 @@ int main(int argc, char **argv) {
     struct ring_buffer *dns_rb = NULL;
     struct ring_buffer *trace_rb = NULL;
     struct ring_buffer *mysql_rb = NULL;
+    struct ring_buffer *redis_rb = NULL;
     struct netwatcher_bpf *skel;
     int err;
     /* Parse command line arguments */
@@ -1333,6 +1353,13 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Failed to create ring buffer(trace)\n");
         goto cleanup;
     }
+    redis_rb = ring_buffer__new(bpf_map__fd(skel->maps.redis_rb), print_redis,
+                                NULL, NULL);
+    if (!redis_rb) {
+        err = -1;
+        fprintf(stderr, "Failed to create ring buffer(trace)\n");
+        goto cleanup;
+    }
     /* Set up ring buffer polling */
     rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), print_packet, NULL, NULL);
     if (!rb) {
@@ -1354,6 +1381,7 @@ int main(int argc, char **argv) {
         err = ring_buffer__poll(dns_rb, 100 /* timeout, ms */);
         err = ring_buffer__poll(trace_rb, 100 /* timeout, ms */);
         err = ring_buffer__poll(mysql_rb, 100 /* timeout, ms */);
+        err = ring_buffer__poll(redis_rb, 100 /* timeout, ms */);
         print_conns(skel);
         sleep(1);
         /* Ctrl-C will cause -EINTR */

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
@@ -180,4 +180,15 @@ typedef struct mysql_query {
     int count;
 } mysql_query;
 
+struct redis_query {
+    int pid;
+    int tid;
+    char comm[20];
+    u32 size;
+    char redis[4][8];
+    u64 duratime;
+    int count;
+    u64 begin_time;
+    int argc;
+};
 #endif /* __NETWATCHER_H */


### PR DESCRIPTION
在输入第二个命令时，才会出现第一个命令的条目，即第一个命令的处理函数在第二个命令进入前才退出，所以拉取到的不是真正的时延，而是输入命令的间隔（不在一个数量级），目前不能确定原因，想重新找一个处理完之后的确认函数来代替现在的uretprobe，或者找到机制的原因
![image](https://github.com/linuxkerneltravel/lmp/assets/93031728/ac6ead37-7ba0-47c2-b9e9-f2a315097129)
