### PR TITLE
mem_watcher：打印每个zone中每个order对应的contig_page_info信息

### DIFF
--- a/eBPF_Supermarket/Memory_Subsystem/mem_watcher/bpf/fraginfo.bpf.c
+++ b/eBPF_Supermarket/Memory_Subsystem/mem_watcher/bpf/fraginfo.bpf.c
@@ -50,7 +50,7 @@ SEC("kprobe/get_page_from_freelist")
 int BPF_KPROBE(get_page_from_freelist, gfp_t gfp_mask, unsigned int order, int alloc_flags,
 	       const struct alloc_context *ac)
 {
-	bpf_printk("1111");
+	// bpf_printk("1111");
 	struct pgdat_info node_info = {};
 	struct zone_info zone_data = {};
 
@@ -82,11 +82,16 @@ int BPF_KPROBE(get_page_from_freelist, gfp_t gfp_mask, unsigned int order, int a
                     zone_data.order = a_order;
 					struct order_zone order_key = {};
 					order_key.order = a_order;
+					if ((u64)z == 0) break;
 					order_key.zone_ptr = (u64)z;
                     struct contig_page_info ctg_info = {};
                     fill_contig_page_info(z, a_order, &ctg_info);
                     bpf_map_update_elem(&orders,&order_key,&ctg_info,BPF_ANY);
-                }
+					bpf_printk("Order: %d, Free pages: %lu, Free blocks total: %lu, Free blocks suitable: %lu", 
+				a_order, ctg_info.free_pages, ctg_info.free_blocks_total, ctg_info.free_blocks_suitable);
+				bpf_printk("2");
+		}
+                
 		bpf_map_update_elem(&zones, &zone_key, &zone_data, BPF_ANY);
 	}
 

--- a/eBPF_Supermarket/Memory_Subsystem/mem_watcher/include/fraginfo.h
+++ b/eBPF_Supermarket/Memory_Subsystem/mem_watcher/include/fraginfo.h
@@ -17,6 +17,8 @@ struct zone_info
 {
     u64 zone_ptr;
     u64 zone_start_pfn;
+    //spanned_pages: 代表的是这个zone中所有的页，包含空洞，计算公式是: zone_end_pfn - zone_start_pfn
+    //present_pages： 代表的是这个zone中可用的所有物理页，计算公式是：spanned_pages-hole_pages
     u64 spanned_pages;
     u64 present_pages;
     char comm[32];


### PR DESCRIPTION
打印每个zone中每个order对应的contig_page_info，并且按照order进行排序输出。输出的分别是该区域内总的空闲页面数、所有大小的空闲块总数以及适合的空闲块数
![1532192e177edc2b93adb5a92dbbe3a](https://github.com/user-attachments/assets/70deeb5a-fbd2-4f07-b8f0-830ca95c5030)
