### PR TITLE
fs_watcher:添加了对磁盘的访问模式的检测，获取每次I/O操作对于磁盘数据的访问模式（disk_io_visit)

### DIFF
--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/open.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/open.bpf.c
@@ -1,0 +1,77 @@
+#define BPF_NO_GLOBAL_DATA
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#define TASK_COMM_LEN 100
+#define path_size 256
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, pid_t);
+	__type(value, char[TASK_COMM_LEN]);
+} data SEC(".maps");
+
+struct event {
+	int pid_;
+	char path_name_[path_size];
+	int n_;
+    char comm[TASK_COMM_LEN];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 256 * 1024);
+} rb SEC(".maps"); // 环形缓冲区
+
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int do_syscall_trace(struct trace_event_raw_sys_enter *ctx)
+{
+	struct event *e;
+    char comm[TASK_COMM_LEN];
+    bpf_get_current_comm(&comm,sizeof(comm));
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e)
+		return 0;
+
+	char filename[path_size];
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task(),
+			   *real_parent;
+	if (task == NULL) {
+		bpf_printk("task\n");
+		bpf_ringbuf_discard(e, 0);
+		return 0;
+	}
+	int pid = bpf_get_current_pid_tgid() >> 32, tgid;
+
+    bpf_map_update_elem(&data, &pid, &comm, BPF_ANY);
+
+	int ppid = BPF_CORE_READ(task, real_parent, tgid);
+
+	bpf_probe_read_str(e->path_name_, sizeof(e->path_name_),
+			   (void *)(ctx->args[1]));
+
+	bpf_printk("path name: %s,pid:%d,ppid:%d\n", e->path_name_, pid, ppid);
+
+	struct fdtable *fdt = BPF_CORE_READ(task, files, fdt);
+	if (fdt == NULL) {
+		bpf_printk("fdt\n");
+		bpf_ringbuf_discard(e, 0);
+		return 0;
+	}
+
+	unsigned int i = 0, count = 0, n = BPF_CORE_READ(fdt, max_fds);
+	bpf_printk("n:%d\n", n);
+
+	e->n_ = n;
+	e->pid_ = pid;
+
+	bpf_ringbuf_submit(e, 0);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/read.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/read.bpf.c
@@ -1,0 +1,99 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "read.h"
+#define MAX_FILENAME_LEN 256
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+// 手动定义文件类型宏
+#define S_IFMT  0170000 // 文件类型掩码  
+#define S_IFREG 0100000 // 普通文件  
+#define S_IFCHR 0020000 // 字符设备  
+#define S_IFDIR 0040000 // 目录  
+#define S_IFLNK 0120000 // 符号链接  
+#define S_IFBLK 0060000 // 块设备  
+#define S_IFIFO 0010000 // FIFO（命名管道）  
+#define S_IFSOCK 0140000 // 套接字
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, pid_t);
+	__type(value, MAX_FILENAME_LEN);
+} data SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 256 * 1024);
+} rb SEC(".maps");
+
+const volatile unsigned long long min_duration_ns = 0;
+
+SEC("kprobe/vfs_read")
+int kprobe_enter_read(struct pt_regs *ctx)
+{
+	struct file *filp = (struct file *)PT_REGS_PARM1(ctx);  
+	pid_t pid;
+	struct event *e;
+	u64 ts;
+	char buf[256];
+	pid = bpf_get_current_pid_tgid() >> 32;
+	ts = bpf_ktime_get_ns()/1000;
+	int count_size = PT_REGS_RC(ctx);
+	if (min_duration_ns)
+		return 0;
+    
+	//获取文件路径结构体
+	struct dentry *dentry = BPF_CORE_READ(filp, f_path.dentry);
+	if(!dentry){
+		bpf_printk("Failed to read dentry\n");
+		return 0;
+	}
+	struct qstr d_name = BPF_CORE_READ(dentry,d_name);
+
+	//读文件名称到缓冲区
+	int ret = bpf_probe_read_kernel(buf, sizeof(buf), d_name.name);
+	if(ret != 0){
+		bpf_printk("failed to read file name\n");
+	}
+	// 判断文件类型，并过滤掉设备文件
+    unsigned short file_type = BPF_CORE_READ(dentry, d_inode, i_mode) & S_IFMT;
+	bpf_map_update_elem(&data, &pid, &buf, BPF_ANY);
+	 switch (file_type) {
+		case S_IFREG:
+            bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+		case S_IFCHR:
+            bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+        case S_IFDIR:
+           bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+        case S_IFLNK:
+           bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+        case S_IFBLK:
+            bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+        case S_IFIFO:
+           bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+        case S_IFSOCK:
+            bpf_printk("Regular file name: %s,count_size :%d", buf,count_size);
+            break;
+		default:
+			bpf_printk("other!!!");
+			break;
+	 }
+	/* reserve sample from BPF ringbuf */
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e)
+		return 0;
+	e->pid = pid;
+	e->duration_ns = ts;
+	/* successfully submit it to user-space for post-processing */
+	bpf_ringbuf_submit(e, 0);
+	return 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/write.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/bpf/write.bpf.c
@@ -1,0 +1,62 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "write.h"
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+#define PATH_MAX 256
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, pid_t);
+	__type(value, int);
+} data SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries,256 * 1024);
+} rb SEC(".maps");
+
+
+SEC("kprobe/vfs_write")
+int kprobe_vfs_write(struct pt_regs *ctx)
+{
+  pid_t pid;
+  struct fs_t *e;
+  unsigned long inode_number;//定义用于存储inode号码的变量
+
+   //探测的是第一个参数，文件指针,读取inode_number
+  struct file *filp = (struct file *)PT_REGS_PARM1(ctx);  
+  struct dentry *dentry = BPF_CORE_READ(filp,f_path.dentry);
+  if(!dentry){
+		bpf_printk("Failed to read dentry\n");
+		return 0;
+	}
+  struct inode *inode = BPF_CORE_READ(dentry,d_inode);
+  if(!inode){
+    bpf_printk("Failed to read inode\n");
+    return 0;
+  }
+  int ret = bpf_probe_read_kernel(&inode_number,sizeof(inode_number),&inode->i_ino);
+
+  //探测的是第三个参数，要写入的字节数
+  size_t count = (size_t)PT_REGS_PARM3(ctx);
+  
+  //这是vfs_write的返回值，它是一个实际写入的字节数
+  size_t real_count = PT_REGS_RC(ctx);
+  
+  pid = bpf_get_current_pid_tgid() >> 32;
+  e = bpf_ringbuf_reserve(&rb,sizeof(*e),0); 
+  if(!e)
+    return 0;
+  
+  e->pid = pid;
+  e->real_count = real_count;
+  e->count = count;
+  e->inode_number = inode_number;
+
+  //这里将获取到的文件指针不为空时
+  bpf_ringbuf_submit(e, 0);
+  return 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/fs_watcher.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/fs_watcher.bpf.c
@@ -1,0 +1,5 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "fs_watcher.h"

--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/fs_watcher.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/fs_watcher.c
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2020 Facebook */
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <linux/fs.h>
+#include <errno.h>
+#include <argp.h>
+#include "open.skel.h"
+#include "read.skel.h"
+#include "write.skel.h"
+#include "fs_watcher.h"
+
+const char argp_program_doc[] = "fs_watcher is in use ....\n";
+
+#define PROCESS_SKEL(skel, func) \
+    skel = func##_bpf__open(); \
+    if (!skel) { \
+        fprintf(stderr, "Failed to open and load BPF skeleton\n"); \
+        return 1; \
+    } \
+    process_##func(skel)
+
+
+#define POLL_RING_BUFFER(rb, timeout, err)     \
+    while (!exiting) {                         \
+        err = ring_buffer__poll(rb, timeout);  \
+        if (err == -EINTR) {                   \
+            err = 0;                           \
+            break;                             \
+        }                                      \
+        if (err < 0) {                         \
+            printf("Error polling perf buffer: %d\n", err); \
+            break;                             \
+        }                                      \
+    }
+
+#define LOAD_AND_ATTACH_SKELETON(skel, event) \
+    do {                                             \
+        err = event##_bpf__load(skel);               \
+        if (err) {                                   \
+            fprintf(stderr, "Failed to load and verify BPF skeleton\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+                                                     \
+        err = event##_bpf__attach(skel);             \
+        if (err) {                                   \
+            fprintf(stderr, "Failed to attach BPF skeleton\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+                                                     \
+        rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event_##event, NULL, NULL); \
+        if (!rb) {                                   \
+            fprintf(stderr, "Failed to create ring buffer\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+    } while(0)
+
+
+#define LOAD_AND_ATTACH_SKELETON_MAP(skel, event) \
+    do {                                             \
+        err = event##_bpf__load(skel);               \
+        if (err) {                                   \
+            fprintf(stderr, "Failed to load and verify BPF skeleton\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+                                                     \
+        err = event##_bpf__attach(skel);             \
+        if (err) {                                   \
+            fprintf(stderr, "Failed to attach BPF skeleton\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+                                                     \
+        int map_fd = bpf_map__fd(skel->maps.data);    \
+        if(!map_fd){                                   \
+            fprintf(stderr, "Failed to find BPF map\n");        \
+            return -1;                                           \
+        }                                                          \
+        rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event_##event, &map_fd, NULL); \
+        if (!rb) {                                   \
+            fprintf(stderr, "Failed to create ring buffer\n"); \
+            goto event##_cleanup;                     \
+        }                                            \
+    } while(0)
+
+static struct env{
+    bool open;
+    bool read;
+    bool write;
+}env = {
+    .open = false,
+    .read = false,
+    .write = false,
+};
+
+static const struct argp_option opts[] = {
+    {"select-function", 0, 0, 0, "Select function:", 1},
+    
+    {"open", 'o', 0, 0, "Print open (open系统调用检测报告)"},
+    
+    {"read", 'r', 0, 0, "Print read (read系统调用检测报告)"},
+    
+    {"write", 'w', 0, 0, "Print write (write系统调用检测报告)"},
+    
+    {0} // 结束标记，用于指示选项列表的结束
+};
+
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state) {
+    switch(key){
+        case 'o':
+        env.open = true;break;
+        case 'r':
+        env.read = true;break;
+        case 'w':
+        env.write = true;break;
+        default: 
+            return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
+}
+
+static const struct argp argp = {
+    .options = opts,
+    .parser = parse_arg,
+    .doc = argp_program_doc,
+};
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+			   va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+static volatile bool exiting = false;
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static int handle_event_open(void *ctx, void *data, size_t data_sz);
+static int handle_event_read(void *ctx, void *data, size_t data_sz);
+static int handle_event_write(void *ctx, void *data, size_t data_sz);
+
+static int process_open(struct open_bpf *skel_open);
+static int process_read(struct read_bpf *skel_read);
+static int process_write(struct write_bpf *skel_write);
+
+
+
+
+int main(int argc,char **argv){
+    
+    int err;
+    struct open_bpf *skel_open;
+    
+    struct read_bpf *skel_read;
+    struct write_bpf *skel_write;
+    libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+     
+
+        /* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+	
+    /* Cleaner handling of Ctrl-C */
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+    signal(SIGALRM, sig_handler);
+   
+
+    err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+      printf("success!\n");
+    if (err)
+        return err;
+
+    if(env.open){
+        PROCESS_SKEL(skel_open,open);
+    }else if(env.read){
+        PROCESS_SKEL(skel_read,read);
+    }else if(env.write){
+        PROCESS_SKEL(skel_write,write);
+    }
+
+}
+
+    static int handle_event_open(void *ctx, void *data, size_t data_sz)
+{
+	struct event_open *e = (struct event_open *)data;
+	char *filename = strrchr(e->path_name_, '/');
+	++filename;
+
+	char fd_path[path_size];
+	char actual_path[path_size];
+    char comm[TASK_COMM_LEN];
+	int i = 0;
+    int map_fd = *(int *)ctx;//传递map得文件描述符
+    
+
+	for (; i < e->n_; ++i) {
+		snprintf(fd_path, sizeof(fd_path), "/proc/%d/fd/%d", e->pid_,
+			 i);
+		ssize_t len =
+			readlink(fd_path, actual_path, sizeof(actual_path) - 1);
+		if (len != -1) {
+			actual_path[len] = '\0';
+			int result = strcmp(e->path_name_, actual_path);
+			if (result == 0) {
+                if(bpf_map_lookup_elem(map_fd,&e->pid_,&comm)==0){
+                    printf("get     ,   filename:%s    ,  fd:%d	, pid:%d  ,comm:%s\n",
+				       e->path_name_, i,e->pid_,comm);
+                }else{
+                    fprintf(stderr, "Failed to lookup value for key %d\n", e->pid_);
+                    }
+				
+			    }
+		    }
+	    }
+	return 0;
+}
+
+
+static int handle_event_read(void *ctx, void *data, size_t data_sz)
+{
+	const struct event_read *e = data;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+
+	printf("%-8s  %-7d  %-7llu\n", ts, e->pid,e->duration_ns);
+	return 0;
+}
+
+static int handle_event_write(void *ctx, void *data, size_t data_sz)
+{
+    const struct fs_t *e = data;
+    struct tm *tm;
+    char ts[32];
+    time_t t;
+    time(&t);
+    tm = localtime(&t);
+    strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+	printf("ts:%-8s  pid:%-7ld inode_number:%-3ld  cout:%-3ld   real_count:%-3ld\n", ts, e->pid,e->inode_number,e->count,e->real_count);
+    return 0;
+}
+
+static int process_open(struct open_bpf *skel_open){
+    int err;
+    struct ring_buffer *rb;
+    
+    LOAD_AND_ATTACH_SKELETON_MAP(skel_open,open);
+
+    printf("%-8s    %-8s    %-8s    %-8s\n","filenamename","fd","pid","comm");
+    POLL_RING_BUFFER(rb, 1000, err);
+
+open_cleanup:
+    ring_buffer__free(rb);
+    open_bpf__destroy(skel_open);
+
+    return err;
+}
+
+static int process_read(struct read_bpf *skel_read){
+    int err;
+    struct ring_buffer *rb;
+    
+    LOAD_AND_ATTACH_SKELETON(skel_read,read);
+
+    printf("%-8s    %-8s    %-8s    %-8s\n","filename","fd","pid","ds");
+    POLL_RING_BUFFER(rb, 1000, err);
+
+read_cleanup:
+    ring_buffer__free(rb);
+    read_bpf__destroy(skel_read);
+
+    return err;
+}
+
+static int process_write(struct write_bpf *skel_write){
+    int err;
+    struct ring_buffer *rb;
+    
+    LOAD_AND_ATTACH_SKELETON(skel_write,write);
+
+    printf("%-8s    %-8s    %-8s    %-8s    %-8s\n","ds","inode_number","pid","real_count","count");
+    POLL_RING_BUFFER(rb, 1000, err);
+
+write_cleanup:
+    ring_buffer__free(rb);
+    write_bpf__destroy(skel_write);
+
+    return err;
+}
+

--- a/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/include/fs_watcher.h
+++ b/eBPF_Supermarket/Filesystem_Subsystem/fs_watcher/include/fs_watcher.h
@@ -1,0 +1,31 @@
+#ifndef __FS_WATCHER_H
+#define __FS_WATCHER_H
+
+/*open*/
+#define path_size 256
+#define TASK_COMM_LEN 16
+
+struct event_open {
+	int pid_;
+	char path_name_[path_size];
+	int n_;
+    char comm[TASK_COMM_LEN];
+};
+
+/*read*/
+
+struct event_read {
+	int pid;
+    unsigned long long duration_ns;
+};
+
+/*write*/
+struct fs_t {
+   unsigned long inode_number;
+    pid_t pid;
+    size_t real_count;
+    size_t count;
+};
+
+
+#endif /* __MEM_WATCHER_H */

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.bpf.c
@@ -1,0 +1,59 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "disk_io_visit.h"
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
+} rb SEC(".maps");
+
+// 进程名与 I/O 计数映射
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key, char[TASK_COMM_LEN]);
+    __type(value, u32);
+} io_count_map SEC(".maps");
+
+SEC("tracepoint/block/block_rq_complete")
+int tracepoint_block_visit(struct trace_event_raw_block_rq_complete *ctx) {
+    struct event *e;
+    u32 *count, new_count;
+    char comm[TASK_COMM_LEN];
+    unsigned long long ts;
+
+    // 获取当前进程名
+    bpf_get_current_comm(comm, sizeof(comm));
+
+    // 查找或初始化该进程的I/O计数
+    count = bpf_map_lookup_elem(&io_count_map, comm);
+    if (count) {
+        new_count = *count + 1;
+    } else {
+        new_count = 1;
+    }
+    bpf_map_update_elem(&io_count_map, comm, &new_count, BPF_ANY);
+
+    // 分配 ringbuf 空间
+    e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+    if (!e) {
+        return 0;
+    }
+
+    // 填充事件数据
+    ts= bpf_ktime_get_ns();
+    e->timestamp = ts;
+    e->blk_dev = ctx->dev;
+    e->sectors = ctx->nr_sector;
+    e->rwbs = (ctx->rwbs[0] == 'R') ? 1 : 0;
+    e->count = new_count;
+    __builtin_memcpy(e->comm, comm, sizeof(comm));
+
+    // 提交事件
+    bpf_ringbuf_submit(e, 0);
+    return 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include "disk_io_visit.h"
+#include "disk_io_visit.skel.h"
+#include <inttypes.h> // For PRIu64
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+    return vfprintf(stderr, format, args);
+}
+
+static volatile bool exiting = false;
+
+static void sig_handler(int sig)
+{
+    exiting = true;
+}
+
+static int handle_event(void *ctx, void *data,unsigned long data_sz) {
+    const struct event *e = data;
+
+    printf("%-10llu %-9d %-7d %-4d %-7d %-16s\n",
+           e->timestamp, e->blk_dev, e->sectors, e->rwbs, e->count, e->comm);
+
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    struct ring_buffer *rb = NULL;
+    struct disk_io_visit_bpf *skel;
+    int err;
+   
+    /* Set up libbpf errors and debug info callback */
+    libbpf_set_print(libbpf_print_fn);
+
+    /* Cleaner handling of Ctrl-C */
+    signal(SIGINT, sig_handler);
+    signal(SIGTERM, sig_handler);
+
+    /* Open BPF application */
+    skel = disk_io_visit_bpf__open();
+    if (!skel) {
+        fprintf(stderr, "Failed to open BPF skeleton\n");
+        return 1;
+    }
+    
+    /* Load & verify BPF programs */
+    err = disk_io_visit_bpf__load(skel);
+    if (err) {
+        fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+        goto cleanup;
+    }
+
+    /* Attach tracepoints */
+    err = disk_io_visit_bpf__attach(skel);
+    if (err) {
+        fprintf(stderr, "Failed to attach BPF skeleton\n");
+        goto cleanup;
+    }
+
+    /* Set up ring buffer polling */
+    rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event, NULL, NULL);
+    if (!rb) {
+        err = -1;
+        fprintf(stderr, "Failed to create ring buffer\n");
+        goto cleanup;
+    }
+
+    printf("%-18s %-7s %-7s %-4s %-7s %-16s\n","TIME", "DEV", "SECTOR", "RWBS", "COUNT", "COMM");
+    while (!exiting) {
+        err = ring_buffer__poll(rb, 100 /* timeout, ms */);
+        /* Ctrl-C will cause -EINTR */
+        if (err == -EINTR) {
+            err = 0;
+            break;
+        }
+
+        if (err < 0) {
+            printf("Error polling ring buffer: %d\n", err);
+            break;
+        } 
+    }
+
+cleanup:
+    /* Clean up */
+    ring_buffer__free(rb);
+    disk_io_visit_bpf__destroy(skel);
+
+    return err < 0 ? -err : 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.h
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/disk_io_visit.h
@@ -1,0 +1,15 @@
+#ifndef DISK_IO_VISIT_H
+#define DISK_IO_VISIT_H
+
+#define TASK_COMM_LEN 256
+
+struct event {
+    long timestamp; // 时间戳
+    int blk_dev; // 块设备号
+    int sectors; // 访问的扇区数
+    int rwbs; // 读写标识符，1表示读操作，0表示写操作
+    int count; // I/O 操作计数
+    char comm[TASK_COMM_LEN]; // 进程名
+};
+
+#endif // DISK_IO_VISIT_H

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.bpf.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.bpf.c
@@ -1,0 +1,62 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "write.h"
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+#define PATH_MAX 256
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__type(key, pid_t);
+	__type(value, int);
+} data SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries,256 * 1024);
+} rb SEC(".maps");
+
+
+SEC("kprobe/vfs_write")
+int kprobe_vfs_write(struct pt_regs *ctx)
+{
+  pid_t pid;
+  struct fs_t *e;
+  unsigned long inode_number;//定义用于存储inode号码的变量
+
+   //探测的是第一个参数，文件指针,读取inode_number
+  struct file *filp = (struct file *)PT_REGS_PARM1(ctx);  
+  struct dentry *dentry = BPF_CORE_READ(filp,f_path.dentry);
+  if(!dentry){
+		bpf_printk("Failed to read dentry\n");
+		return 0;
+	}
+  struct inode *inode = BPF_CORE_READ(dentry,d_inode);
+  if(!inode){
+    bpf_printk("Failed to read inode\n");
+    return 0;
+  }
+  int ret = bpf_probe_read_kernel(&inode_number,sizeof(inode_number),&inode->i_ino);
+
+  //探测的是第三个参数，要写入的字节数
+  size_t count = (size_t)PT_REGS_PARM3(ctx);
+  
+  //这是vfs_write的返回值，它是一个实际写入的字节数
+  size_t real_count = PT_REGS_RC(ctx);
+  
+  pid = bpf_get_current_pid_tgid() >> 32;
+  e = bpf_ringbuf_reserve(&rb,sizeof(*e),0); 
+  if(!e)
+    return 0;
+  
+  e->pid = pid;
+  e->real_count = real_count;
+  e->count = count;
+  e->inode_number = inode_number;
+
+  //这里将获取到的文件指针不为空时
+  bpf_ringbuf_submit(e, 0);
+  return 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.c
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <signal.h>
+#include <unistd.h>
+#include <sys/resource.h>
+#include <time.h>
+#include <stdlib.h>
+#include "write.h"
+#include "write.skel.h"
+
+#define PATH_MAX 128
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+static volatile bool exiting = false;
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static int write_event(void *ctx, void *data, size_t data_sz)
+{
+    const struct fs_t *e = data;
+    struct tm *tm;
+    char ts[32];
+    time_t t;
+    time(&t);
+    tm = localtime(&t);
+    strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+	printf("ts:%-8s  pid:%-7ld  inode_number:%-7ld   cout:%-7ld   real_count:%-7ld\n", ts, e->pid,e->inode_number,e->count,e->real_count);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    struct ring_buffer *rb = NULL;
+    struct write_bpf *skel;
+	int err;
+   
+    /* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	
+	/* Cleaner handling of Ctrl-C */
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+
+    /* Open BPF application */
+	skel = write_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+    
+	/* Load & verify BPF programs */
+	err = write_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+		goto cleanup;
+	}
+
+    /* Attach tracepoints */
+	err = write_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+
+    /* Set up ring buffer polling */
+	rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), write_event, NULL, NULL);
+	if (!rb) {
+		err = -1;
+		fprintf(stderr, "Failed to create ring buffer\n");
+		goto cleanup;
+	}
+
+    /* Process events */
+	while (!exiting) {
+		err = ring_buffer__poll(rb, 100 /* timeout, ms */);
+		/* Ctrl-C will cause -EINTR */
+		if (err == -EINTR) {
+			err = 0;
+			break;
+		}
+
+		if (err < 0) {
+			printf("Error polling perf buffer: %d\n", err);
+			break;
+		}
+	}
+
+cleanup:
+	/* Clean up */
+	ring_buffer__free(rb);
+	write_bpf__destroy(skel);
+
+	return err < 0 ? -err : 0;
+}

--- a/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.h
+++ b/eBPF_Supermarket/Filesystem_Subsystem/old_project/write.h
@@ -1,0 +1,11 @@
+#ifndef __WRITE_H
+#define __WRITE_H
+
+struct fs_t {
+    unsigned long inode_number;
+    pid_t pid;
+    size_t real_count;
+    size_t count;
+};
+
+#endif /* __WRITE_H */


### PR DESCRIPTION
struct event {
    long timestamp; // 时间戳
    int blk_dev; // 块设备号
    int sectors; // 访问的扇区数
    int rwbs; // 读写标识符，1表示读操作，0表示写操作
    int count; // I/O 操作计数
    char comm[TASK_COMM_LEN]; // 进程名
};
检测了这些在磁盘访问的时候，这些数据
![68](https://github.com/user-attachments/assets/1d609e6c-a2b4-4314-b34c-573d6793efc3)
