### PR TITLE
netwatcher：监测TCP的RST重置事件

### DIFF
--- a/.github/workflows/ebpf_net_watcher.yml
+++ b/.github/workflows/ebpf_net_watcher.yml
@@ -48,4 +48,8 @@ jobs:
           sudo timeout -s SIGINT 5 ./netwatcher -S || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
           sudo timeout -s SIGINT 5 ./netwatcher -D || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
           sudo timeout -s SIGINT 5 ./netwatcher -M || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -R || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -C || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -T || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
+          sudo timeout -s SIGINT 5 ./netwatcher -U || if [[ $? != 124 && $? != 0 ]];then exit $?;fi
         timeout-minutes: 5

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.bpf.c
@@ -307,12 +307,6 @@ int BPF_KPROBE(icmp_reply, struct icmp_bxm *icmp_param, struct sk_buff *skb) {
     return __reply_icmp_time(skb);
 }
 
-// tcpstate
-SEC("tracepoint/sock/inet_sock_set_state")
-int handle_set_state(struct trace_event_raw_inet_sock_set_state *ctx) {
-    return __handle_set_state(ctx);
-}
-
 // mysql
 SEC("uprobe/_Z16dispatch_commandP3THDPK8COM_DATA19enum_server_command")
 int BPF_KPROBE(query__start) { return __handle_mysql_start(ctx); }
@@ -328,4 +322,20 @@ int BPF_KPROBE(query__end_redis) { return __handle_redis_end(ctx); }
 SEC("kprobe/tcp_rcv_established")
 int BPF_KPROBE(tcp_rcv_established, struct sock *sk, struct sk_buff *skb) {
     return __tcp_rcv_established(sk, skb);
+}
+
+// tcpstate
+SEC("tracepoint/sock/inet_sock_set_state")
+int handle_set_state(struct trace_event_raw_inet_sock_set_state *ctx) {
+    return __handle_set_state(ctx);
+}
+// RST
+SEC("tracepoint/tcp/tcp_send_reset")
+int handle_send_reset(struct trace_event_raw_tcp_send_reset *ctx) {
+    return __handle_send_reset(ctx);
+}
+
+SEC("tracepoint/tcp/tcp_receive_reset")
+int handle_receive_reset(struct trace_event_raw_tcp_receive_reset *ctx) {
+    return __handle_receive_reset(ctx);
 }

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 static volatile bool exiting = false;
 

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/netwatcher.h
@@ -200,4 +200,20 @@ struct RTT {
     u64 latency;
     u64 cnt;
 };
+
+struct reset_event_t {
+    int pid;
+    char comm[16];
+    u16 family;
+    unsigned __int128 saddr_v6;
+    unsigned __int128 daddr_v6;
+    u32 saddr;
+    u32 daddr;
+    u16 sport;
+    u16 dport;
+    u8 direction; // 0 for send, 1 for receive
+    u64 count;
+    u64 timestamp;
+    u8 state;
+};
 #endif /* __NETWATCHER_H */

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/tcp.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/tcp.bpf.h
@@ -380,16 +380,21 @@ static __always_inline int ret(void *ctx, __u8 direction, __u16 sport,
         message->daddr_v6 = 0;
     } else if (message->family == AF_INET6) {
         if (direction == 0) { // Send
-            BPF_CORE_READ_INTO(&message->saddr_v6, sk,
-                               __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-            BPF_CORE_READ_INTO(&message->daddr_v6, sk,
-                               __sk_common.skc_v6_daddr.in6_u.u6_addr32);
+            bpf_probe_read_kernel(
+                &message->saddr_v6, sizeof(message->saddr_v6),
+                &sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+            bpf_probe_read_kernel(
+                &message->daddr_v6, sizeof(message->daddr_v6),
+                &sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         } else { // Receive
-            BPF_CORE_READ_INTO(&message->saddr_v6, sk,
-                               __sk_common.skc_v6_daddr.in6_u.u6_addr32);
-            BPF_CORE_READ_INTO(&message->daddr_v6, sk,
-                               __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+            bpf_probe_read_kernel(
+                &message->saddr_v6, sizeof(message->saddr_v6),
+                &sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+            bpf_probe_read_kernel(
+                &message->daddr_v6, sizeof(message->daddr_v6),
+                &sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
         }
+
         message->saddr = 0;
         message->daddr = 0;
     }
@@ -424,7 +429,7 @@ __handle_send_reset(struct trace_event_raw_tcp_send_reset *ctx) {
     struct sock *sk = (struct sock *)ctx->skaddr;
     if (!sk)
         return 0;
-    bpf_printk("Send reset: sport=%u, dport=%u\n", ctx->sport, ctx->dport);
+    //   bpf_printk("Send reset: sport=%u, dport=%u\n", ctx->sport, ctx->dport);
     return ret((void *)ctx->skaddr, 0, ctx->sport, ctx->dport);
 }
 
@@ -433,6 +438,7 @@ __handle_receive_reset(struct trace_event_raw_tcp_receive_reset *ctx) {
     struct sock *sk = (struct sock *)ctx->skaddr;
     if (!sk)
         return 0;
-    bpf_printk("Receive reset: sport=%u, dport=%u\n", ctx->sport, ctx->dport);
+    //  bpf_printk("Receive reset: sport=%u, dport=%u\n", ctx->sport,
+    //  ctx->dport);
     return ret((void *)ctx->skaddr, 1, ctx->sport, ctx->dport);
 }

--- a/eBPF_Supermarket/Network_Subsystem/net_watcher/tcp.bpf.h
+++ b/eBPF_Supermarket/Network_Subsystem/net_watcher/tcp.bpf.h
@@ -354,8 +354,8 @@ static __always_inline int __tcp_rcv_established(struct sock *sk,
     return 0;
 }
 
-static __always_inline int ret(void *ctx, __u8 direction, __u16 sport,
-                               __u16 dport) {
+static __always_inline int ret(void *ctx, u8 direction, u16 sport,
+                               u16 dport) {
     struct reset_event_t *message =
         bpf_ringbuf_reserve(&events, sizeof(*message), 0);
     if (!message)
@@ -409,12 +409,12 @@ static __always_inline int ret(void *ctx, __u8 direction, __u16 sport,
     message->direction = direction;
 
     // 增加 RST 计数
-    __u32 pid = message->pid;
-    __u64 *count = bpf_map_lookup_elem(&counters, &pid);
+    u32 pid = message->pid;
+    u64 *count = bpf_map_lookup_elem(&counters, &pid);
     if (count) {
         *count += 1;
     } else {
-        __u64 initial_count = 1;
+        u64 initial_count = 1;
         bpf_map_update_elem(&counters, &pid, &initial_count, BPF_ANY);
         count = &initial_count;
     }


### PR DESCRIPTION
监测5s内TCP的RST重置事件次数，其记录信息有当前进程信息、数据包四元组信息、以及产生RST复位事件的时间戳，t为测试程序，用于发送TCP RST 包，捕获成功。
![15496f2d9dbfc99ea0c75403e2df769](https://github.com/user-attachments/assets/6299dbda-9350-44a4-ae08-c3200dab43ed)
