### PR TITLE
Proc_image: fix compile error: undefined reference to 'pthread_join'

### DIFF
--- a/eBPF_Supermarket/CPU_Subsystem/eBPF_proc_image/Makefile
+++ b/eBPF_Supermarket/CPU_Subsystem/eBPF_proc_image/Makefile
@@ -142,7 +142,7 @@ $(CONTROLLER): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
 
 $(WORKTOOL): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $^ $(ALL_LDFLAGS) -lstdc++ -lelf -lz -o $@
+	$(Q)$(CC) $^ $(ALL_LDFLAGS) -lstdc++ -lelf -lz -lpthread -o $@
 	@mkdir -p $(OUTPUT)/data
 	@[ -f $(OUTPUT)/data/offcpu_stack.txt ] || touch $(OUTPUT)/data/offcpu_stack.txt
 


### PR DESCRIPTION
# Pull Request Template

## Description/描述
https://github.com/linuxkerneltravel/lmp/issues/793 描述进程画像程序编译时报错，找不到pthread库，在Makefile中链接上pthread库。

Fixes # (issue)

## Type of change /PR 类型

- [x] Bug fix (non-breaking change which fixes an issue)

