### PR TITLE
fs_watcher:添加-n选项进行filename过滤 && 添加logo图案 && 将read程序重新修改输出 

### DIFF
--- a/MagicEyes/src/backend/fs/fs_watcher/include/fs_watcher.h
+++ b/MagicEyes/src/backend/fs/fs_watcher/include/fs_watcher.h
@@ -6,20 +6,20 @@
 #define TASK_COMM_LEN 16
 
 struct event_open {
-    pid_t pid;
-    int dfd;
-    char filename[path_size];
-    int flags;
-    int fd;    // 文件描述符
-    int ret;   // 系统调用返回值
-    bool is_created;  // 标记文件是否创建
+    pid_t pid;          // 进程 ID
+    int dfd;            // 目录文件描述符
+    char filename[256]; // 文件路径
+    int flags;          // 打开标志
+    int fd;             // 文件描述符
+    int ret;            // 系统调用返回值
 };
 
 /*read*/
-
 struct event_read {
-	int pid;
-    unsigned long long duration_ns;
+    int pid;
+    char filename[256]; // 文件名
+    int count_size;     // 读取的字节数
+    unsigned short file_type; // 文件类型
 };
 
 /*write*/
@@ -64,9 +64,4 @@ struct event_CacheTrack{
     long long time_complete;  // 写回开始时间
 };
 
-/*send pid to ebpf*/
-struct dist_args {
-    pid_t pid;
-};
-#endif /* __MEM_WATCHER_H */
-
+#endif /* __FS_WATCHER_H */


### PR DESCRIPTION
1、添加-n（filename)过滤选项，这个是open的
![上汽_1](https://github.com/user-attachments/assets/cfc001f7-5eee-4b37-a04b-bcbc9341b7df)
2、添加fs watcher图案logo打印，将选项进项重新设计和排序
![上汽_2](https://github.com/user-attachments/assets/32918d4a-e97f-476c-89bd-cdadb434eb8b)
3、这个是read的使用-n（filename)进行过滤
![上汽_3](https://github.com/user-attachments/assets/29e05abc-be5f-47fe-9684-01f64629b098)
