### PR TITLE
[net_watcher] bug fix: invalid func unknown#177 bucause bpf_printk only support 3 argument in old kernel, test in version 5.15

### DIFF
--- a/MagicEyes/src/backend/net/net_watcher/bpf/udp.bpf.h
+++ b/MagicEyes/src/backend/net/net_watcher/bpf/udp.bpf.h
@@ -79,8 +79,14 @@ static __always_inline int __udp_send_skb(struct sk_buff *skb) {
     pkt_tuple.tran_flag = UDP;
     FILTER
     struct ktime_info *tinfo, zero = {0};
-    bpf_printk("udp_send_skb%d %d %d %d", pkt_tuple.saddr, pkt_tuple.daddr,
-               pkt_tuple.sport, pkt_tuple.dport);
+    /** 注意： 
+     * bpf_printk在老的Linux内核（在kernel 5.15测试）上，只支持三个以内的参数
+     * 可查看： https://github.com/libbpf/libbpf-bootstrap/issues/206
+    */
+    //bpf_printk("udp_send_skb%d %d %d %d", pkt_tuple.saddr, pkt_tuple.daddr,
+    //           pkt_tuple.sport, pkt_tuple.dport);
+    bpf_printk("udp_send_skb s&d addr: %d %d", pkt_tuple.saddr, pkt_tuple.daddr);
+    bpf_printk("udp_send_skb s&d port: %d %d", pkt_tuple.sport, pkt_tuple.dport);
     tinfo = (struct ktime_info *)bpf_map_lookup_or_try_init(&timestamps,
                                                             &pkt_tuple, &zero);
     if (tinfo == NULL) {


### PR DESCRIPTION

## Description/描述
```bash
uname -a
Linux fzy-Lenovo 5.15.0-130-generic #140~20.04.1-Ubuntu SMP Wed Dec 18 21:35:34 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```
在以上平台上运行 `sudo net_watcher -u`时发现运行报错，如下：
```bash
; struct ktime_info *tinfo, zero = {0};
124: (07) r3 += -416
; bpf_printk("udp_send_skb%d %d %d %d", pkt_tuple.saddr, pkt_tuple.daddr,
125: (18) r1 = 0xffffb2780075008c
127: (b7) r2 = 24
128: (b7) r4 = 32
129: (85) call unknown#177
invalid func unknown#177
```
原因是在老平台上，bpf_printk支持三个以下的参数，而代码中打印了4个参数。解决办法为打印时拆开
更多信息可查看： https://github.com/libbpf/libbpf-bootstrap/issues/206

Fixes # (issue)

## Type of change /PR 类型

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?/ 测试方式
```bash
               __                          __           __                       
             /\ \__                      /\ \__       /\ \                      
  ___      __\ \  _\  __  __  __     __  \ \  _\   ___\ \ \___      __   _ __   
/  _  \  / __ \ \ \/ /\ \/\ \/\ \  / __ \ \ \ \/  / ___\ \  _  \  / __ \/\  __\ 
/\ \/\ \/\  __/\ \ \_\ \ \_/ \_/ \/\ \_\ \_\ \ \_/\ \__/\ \ \ \ \/\  __/\ \ \/  
\ \_\ \_\ \____\ \__\ \_______ / /\ \__/\ \_\ \__\ \____/\ \_\ \_\ \____ \ \_\  
 \/_/\/_/\/____/ \/__/ \/__//__ /  \/_/  \/_/\/__/\/____/ \/_/\/_/\/____/ \/_/  

===============================================================UDP INFORMATION========================================================
Saddr                Sport                Daddr                Dprot                udp_time/μs         RX/direction         len/byte            
127.0.0.1            43652                127.0.0.53           53                   4                    0                    53                  

127.0.0.1            43652                127.0.0.53           53                   6                    1                    53                  

127.0.0.53           53                   127.0.0.1            43652                5                    1                    260         
```


## Checklist/检查列表

- [X] My code follows the style guidelines of this project /代码规范检查
- [X] I have performed a self-review of my own code / 自己已经检查代码
- [X] I have commented my code, particularly in hard-to-understand areas / 有代码注释，尤其是关键代码
- [X] My changes generate no new warnings / 变更没有新产生告警

