### PR TITLE
fix: Add Fedora support and automatically detect KVM to generate vmlinux.h

### DIFF
--- a/eBPF_Supermarket/eBPF_Performance_Analysis/Makefile
+++ b/eBPF_Supermarket/eBPF_Performance_Analysis/Makefile
@@ -21,18 +21,28 @@ default: bpf
 # 安装必要的依赖
 .PHONY: deps
 deps:
-	sudo apt-get update && \
-	sudo apt-get install -y clang libelf1 libelf-dev zlib1g-dev libbpf-dev \
-		 linux-tools-$$(uname -r) linux-cloud-tools-$$(uname -r) \
-		 libpcap-dev gcc-multilib build-essential lolcat 
+	@if [ -f /etc/fedora-release ]; then \
+		sudo dnf update && \
+		sudo dnf install -y clang llvm libbpf-devel elfutils-libelf-devel \
+			zlib-devel libzstd-devel bpftool libpcap-devel; \
+	else \
+		sudo apt-get update && \
+		sudo apt-get install -y clang libelf1 libelf-dev zlib1g-dev libbpf-dev \
+			linux-tools-$$(uname -r) linux-cloud-tools-$$(uname -r) \
+			libpcap-dev gcc-multilib build-essential lolcat; \
+	fi
 
 # 头文件目录
 INCLUDE_DIRS=-I/usr/include/x86_64-linux-gnu -I. -I./include -I./include/bpf -I./include/helpers
 # 生成 vmlinux.h
 .PHONY: vmlinux
 vmlinux:
-	bpftool btf dump file /sys/kernel/btf/kvm format c > ./include/vmlinux.h
-	
+	@if [ -f /sys/kernel/btf/kvm ]; then \
+		bpftool btf dump file /sys/kernel/btf/kvm format c > ./include/vmlinux.h; \
+	else \
+		bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./include/vmlinux.h; \
+	fi
+
 # 编译BPF程序
 $(APP).bpf.o: $(APP).bpf.c vmlinux
 	clang $(BPF_CFLAGS) -D__TARGET_ARCH_$(ARCH) $(INCLUDE_DIRS) -c $< -o $@

--- a/eBPF_Supermarket/eBPF_Performance_Analysis/README.md
+++ b/eBPF_Supermarket/eBPF_Performance_Analysis/README.md
@@ -37,7 +37,7 @@ python3 --version
 #下载pandas库
 sudo pip3 install pandas -i https://pypi.tuna.tsinghua.edu.cn/simple
 #下载matplotlib库
-pip3 install matplotlib
+sudo pip3 install matplotlib
 ```
 
 2.运行：


### PR DESCRIPTION
# 修改内容
- 原Makefile仅支持Debian/Ubuntu系发行版，添加Fedora发行版的依赖安装支持
- KVM BTF文件在某些环境可能不存在，实现自动检测KVM BTF信息，不存在时回退到vmlinux
- 更新文档说明（添加`sudo`确保权限正确）
      
# 测试验证
已在以下环境测试：
- Fedora 38（使用dnf安装依赖）
- Ubuntu 22.04（保持原有apt安装流程）
- 无KVM环境（自动生成vmlinux.h）