### PR TITLE
add kvmwatcher amd_svm vm_exit reason

### DIFF
--- a/eBPF_Supermarket/kvm_watcher/include/common.h
+++ b/eBPF_Supermarket/kvm_watcher/include/common.h
@@ -29,38 +29,39 @@
         }                                                                    \
     } while (0)
 
-static const char binary_path[] = "/bin/qemu-system-x86_64";
-#define __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe)               \
-    do {                                                                      \
-        LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .func_name = #sym_name,     \
-                    .retprobe = is_retprobe);                                 \
-        skel->links.prog_name = bpf_program__attach_uprobe_opts(              \
-            skel->progs.prog_name, env.vm_pid, binary_path, 0, &uprobe_opts); \
-    } while (false)
+// static const char binary_path[] = "/bin/qemu-system-x86_64";
+// #define __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe)               \
+//     do {                                                                      \
+//         LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts, .func_name = #sym_name,     \
+//                      .retprobe = is_retprobe);
+//                                  \
+//         skel->links.prog_name = bpf_program__attach_uprobe_opts(              \
+//             skel->progs.prog_name, env.vm_pid, binary_path, 0, &uprobe_opts); \
+//     } while (false)
 
-#define __CHECK_PROGRAM(skel, prog_name)                   \
-    do {                                                   \
-        if (!skel->links.prog_name) {                      \
-            perror("no program attached for " #prog_name); \
-            return -errno;                                 \
-        }                                                  \
-    } while (false)
+// #define __CHECK_PROGRAM(skel, prog_name)                   \
+//     do {                                                   \
+//         if (!skel->links.prog_name) {                      \
+//             perror("no program attached for " #prog_name); \
+//             return -errno;                                 \
+//         }                                                  \
+//     } while (false)
 
-#define __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, is_retprobe) \
-    do {                                                                \
-        __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe);        \
-        __CHECK_PROGRAM(skel, prog_name);                               \
-    } while (false)
+// #define __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, is_retprobe) \
+//     do {                                                                \
+//         __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe);        \
+//         __CHECK_PROGRAM(skel, prog_name);                               \
+//     } while (false)
 
-#define ATTACH_UPROBE(skel, sym_name, prog_name) \
-    __ATTACH_UPROBE(skel, sym_name, prog_name, false)
-#define ATTACH_URETPROBE(skel, sym_name, prog_name) \
-    __ATTACH_UPROBE(skel, sym_name, prog_name, true)
+// #define ATTACH_UPROBE(skel, sym_name, prog_name) \
+//     __ATTACH_UPROBE(skel, sym_name, prog_name, false)
+// #define ATTACH_URETPROBE(skel, sym_name, prog_name) \
+//     __ATTACH_UPROBE(skel, sym_name, prog_name, true)
 
-#define ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name) \
-    __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, false)
-#define ATTACH_URETPROBE_CHECKED(skel, sym_name, prog_name) \
-    __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, true)
+// #define ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name) \
+//     __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, false)
+// #define ATTACH_URETPROBE_CHECKED(skel, sym_name, prog_name) \
+//     __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, true)
 
 #define TASK_COMM_LEN 16
 #define KVM_MEM_LOG_DIRTY_PAGES (1UL << 0)

--- a/eBPF_Supermarket/kvm_watcher/include/helpers/amd_svm_exit.h
+++ b/eBPF_Supermarket/kvm_watcher/include/helpers/amd_svm_exit.h
@@ -1,0 +1,135 @@
+// include/helpers/amd_svm_exit.h
+#ifndef AMD_SVM_EXIT_H
+#define AMD_SVM_EXIT_H
+
+#define SVM_EXIT_READ_CR0      0x000
+#define SVM_EXIT_READ_CR2      0x002
+#define SVM_EXIT_READ_CR3      0x003
+#define SVM_EXIT_READ_CR4      0x004
+#define SVM_EXIT_READ_CR8      0x008
+#define SVM_EXIT_WRITE_CR0     0x010
+#define SVM_EXIT_WRITE_CR2     0x012
+#define SVM_EXIT_WRITE_CR3     0x013
+#define SVM_EXIT_WRITE_CR4     0x014
+#define SVM_EXIT_WRITE_CR8     0x018
+#define SVM_EXIT_READ_DR0      0x020
+#define SVM_EXIT_READ_DR1      0x021
+#define SVM_EXIT_READ_DR2      0x022
+#define SVM_EXIT_READ_DR3      0x023
+#define SVM_EXIT_READ_DR4      0x024
+#define SVM_EXIT_READ_DR5      0x025
+#define SVM_EXIT_READ_DR6      0x026
+#define SVM_EXIT_READ_DR7      0x027
+#define SVM_EXIT_WRITE_DR0     0x030
+#define SVM_EXIT_WRITE_DR1     0x031
+#define SVM_EXIT_WRITE_DR2     0x032
+#define SVM_EXIT_WRITE_DR3     0x033
+#define SVM_EXIT_WRITE_DR4     0x034
+#define SVM_EXIT_WRITE_DR5     0x035
+#define SVM_EXIT_WRITE_DR6     0x036
+#define SVM_EXIT_WRITE_DR7     0x037
+#define SVM_EXIT_EXCP_BASE     0x040
+#define SVM_EXIT_LAST_EXCP     0x05f
+#define SVM_EXIT_INTR          0x060
+#define SVM_EXIT_NMI           0x061
+#define SVM_EXIT_SMI           0x062
+#define SVM_EXIT_INIT          0x063
+#define SVM_EXIT_VINTR         0x064
+#define SVM_EXIT_CR0_SEL_WRITE 0x065
+#define SVM_EXIT_IDTR_READ     0x066
+#define SVM_EXIT_GDTR_READ     0x067
+#define SVM_EXIT_LDTR_READ     0x068
+#define SVM_EXIT_TR_READ       0x069
+#define SVM_EXIT_IDTR_WRITE    0x06a
+#define SVM_EXIT_GDTR_WRITE    0x06b
+#define SVM_EXIT_LDTR_WRITE    0x06c
+#define SVM_EXIT_TR_WRITE      0x06d
+#define SVM_EXIT_RDTSC         0x06e
+#define SVM_EXIT_RDPMC         0x06f
+#define SVM_EXIT_PUSHF         0x070
+#define SVM_EXIT_POPF          0x071
+#define SVM_EXIT_CPUID         0x072
+#define SVM_EXIT_RSM           0x073
+#define SVM_EXIT_IRET          0x074
+#define SVM_EXIT_SWINT         0x075
+#define SVM_EXIT_INVD          0x076
+#define SVM_EXIT_PAUSE         0x077
+#define SVM_EXIT_HLT           0x078
+#define SVM_EXIT_INVLPG        0x079
+#define SVM_EXIT_INVLPGA       0x07a
+#define SVM_EXIT_IOIO          0x07b
+#define SVM_EXIT_MSR           0x07c
+#define SVM_EXIT_TASK_SWITCH   0x07d
+#define SVM_EXIT_FERR_FREEZE   0x07e
+#define SVM_EXIT_SHUTDOWN      0x07f
+#define SVM_EXIT_VMRUN         0x080
+#define SVM_EXIT_VMMCALL       0x081
+#define SVM_EXIT_VMLOAD        0x082
+#define SVM_EXIT_VMSAVE        0x083
+#define SVM_EXIT_STGI          0x084
+#define SVM_EXIT_CLGI          0x085
+#define SVM_EXIT_SKINIT        0x086
+#define SVM_EXIT_RDTSCP        0x087
+#define SVM_EXIT_ICEBP         0x088
+#define SVM_EXIT_WBINVD        0x089
+#define SVM_EXIT_MONITOR       0x08a
+#define SVM_EXIT_MWAIT         0x08b
+#define SVM_EXIT_MWAIT_COND    0x08c
+#define SVM_EXIT_XSETBV        0x08d
+#define SVM_EXIT_RDPRU         0x08e
+#define SVM_EXIT_EFER_WRITE_TRAP		0x08f
+#define SVM_EXIT_CR0_WRITE_TRAP			0x090
+#define SVM_EXIT_CR1_WRITE_TRAP			0x091
+#define SVM_EXIT_CR2_WRITE_TRAP			0x092
+#define SVM_EXIT_CR3_WRITE_TRAP			0x093
+#define SVM_EXIT_CR4_WRITE_TRAP			0x094
+#define SVM_EXIT_CR5_WRITE_TRAP			0x095
+#define SVM_EXIT_CR6_WRITE_TRAP			0x096
+#define SVM_EXIT_CR7_WRITE_TRAP			0x097
+#define SVM_EXIT_CR8_WRITE_TRAP			0x098
+#define SVM_EXIT_CR9_WRITE_TRAP			0x099
+#define SVM_EXIT_CR10_WRITE_TRAP		0x09a
+#define SVM_EXIT_CR11_WRITE_TRAP		0x09b
+#define SVM_EXIT_CR12_WRITE_TRAP		0x09c
+#define SVM_EXIT_CR13_WRITE_TRAP		0x09d
+#define SVM_EXIT_CR14_WRITE_TRAP		0x09e
+#define SVM_EXIT_CR15_WRITE_TRAP		0x09f
+#define SVM_EXIT_INVPCID       0x0a2
+#define SVM_EXIT_NPF           0x400
+#define SVM_EXIT_AVIC_INCOMPLETE_IPI		0x401
+#define SVM_EXIT_AVIC_UNACCELERATED_ACCESS	0x402
+#define SVM_EXIT_VMGEXIT       0x403
+
+/* SEV-ES software-defined VMGEXIT events */
+#define SVM_VMGEXIT_MMIO_READ			0x80000001
+#define SVM_VMGEXIT_MMIO_WRITE			0x80000002
+#define SVM_VMGEXIT_NMI_COMPLETE		0x80000003
+#define SVM_VMGEXIT_AP_HLT_LOOP			0x80000004
+#define SVM_VMGEXIT_AP_JUMP_TABLE		0x80000005
+#define SVM_VMGEXIT_SET_AP_JUMP_TABLE		0
+#define SVM_VMGEXIT_GET_AP_JUMP_TABLE		1
+#define SVM_VMGEXIT_PSC				0x80000010
+#define SVM_VMGEXIT_GUEST_REQUEST		0x80000011
+#define SVM_VMGEXIT_EXT_GUEST_REQUEST		0x80000012
+#define SVM_VMGEXIT_AP_CREATION			0x80000013
+#define SVM_VMGEXIT_AP_CREATE_ON_INIT		0
+#define SVM_VMGEXIT_AP_CREATE			1
+#define SVM_VMGEXIT_AP_DESTROY			2
+#define SVM_VMGEXIT_HV_FEATURES			0x8000fffd
+#define SVM_VMGEXIT_TERM_REQUEST		0x8000fffe
+#define SVM_VMGEXIT_TERM_REASON(reason_set, reason_code)	\
+	/* SW_EXITINFO1[3:0] */					\
+	(((((u64)reason_set) & 0xf)) |				\
+	/* SW_EXITINFO1[11:4] */				\
+	((((u64)reason_code) & 0xff) << 4))
+#define SVM_VMGEXIT_UNSUPPORTED_EVENT		0x8000ffff
+
+/* Exit code reserved for hypervisor/software use */
+#define SVM_EXIT_SW				0xf0000000
+
+#define SVM_EXIT_ERR           -1
+
+#define SVM_EXIT_BUS_LOCK   0x09a
+#define SVM_EXIT_IDLE_HLT   0x09f
+
+#endif

--- a/eBPF_Supermarket/kvm_watcher/src/kvm_watcher.c
+++ b/eBPF_Supermarket/kvm_watcher/src/kvm_watcher.c
@@ -31,6 +31,75 @@
 #include "trace_helpers.h"
 #include "uprobe_helpers.h"
 #include "kvm_watcher.skel.h"
+#include "amd_svm_exit.h"
+static const char binary_path[] = "/bin/qemu-system-x86_64";
+
+#define __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe)               \
+    do {                                                                      \
+        LIBBPF_OPTS(bpf_uprobe_opts, uprobe_opts,                             \
+                    .func_name = #sym_name,                                   \
+                    .retprobe = is_retprobe);                                 \
+        skel->links.prog_name = bpf_program__attach_uprobe_opts(              \
+            skel->progs.prog_name, env.vm_pid, binary_path, 0, &uprobe_opts); \
+    } while (false)
+
+#define __CHECK_PROGRAM(skel, prog_name)                   \
+    do {                                                   \
+        if (!skel->links.prog_name) {                      \
+            perror("no program attached for " #prog_name); \
+            return -errno;                                 \
+        }                                                  \
+    } while (false)
+
+#define __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, is_retprobe) \
+    do {                                                                \
+        __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe);        \
+        __CHECK_PROGRAM(skel, prog_name);                               \
+    } while (false)
+
+#define ATTACH_UPROBE(skel, sym_name, prog_name) \
+    __ATTACH_UPROBE(skel, sym_name, prog_name, false)
+
+#define ATTACH_URETPROBE(skel, sym_name, prog_name) \
+    __ATTACH_UPROBE(skel, sym_name, prog_name, true)
+
+#define ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name) \
+    __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, false)
+
+#define ATTACH_URETPROBE_CHECKED(skel, sym_name, prog_name) \
+    __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, true)
+
+
+
+enum KvmVendor {
+    KVM_VENDOR_INTEL = 0,
+    KVM_VENDOR_AMD = 1,
+};
+
+static enum KvmVendor current_vendor = KVM_VENDOR_INTEL;
+
+static enum KvmVendor detect_kvm_vendor(void)
+{
+    FILE *fp = fopen("/proc/cpuinfo", "r");
+    char buf[256];
+
+    if (!fp)
+        return KVM_VENDOR_INTEL;
+
+    while (fgets(buf, sizeof(buf), fp)) {
+        if (strstr(buf, "AuthenticAMD")) {
+            fclose(fp);
+            return KVM_VENDOR_AMD;
+        }
+        if (strstr(buf, "GenuineIntel")) {
+            fclose(fp);
+            return KVM_VENDOR_INTEL;
+        }
+    }
+
+    fclose(fp);
+    return KVM_VENDOR_INTEL;
+}
 
 
 //可视化调整输出格式
@@ -58,6 +127,8 @@ FILE *create_temp_file(const char *filename) {
 
     return output;
 }
+
+
 
 const char *getName(int number, enum NameType type) {
     struct NameMapping {
@@ -127,6 +198,70 @@ const char *getName(int number, enum NameType type) {
                                         {68, "TPAUSE"},
                                         {74, "BUS_LOCK"},
                                         {75, "NOTIFY"}};
+    struct NameMapping svmExitReasons[] = {
+    { SVM_EXIT_READ_CR0, "read_cr0" },
+    { SVM_EXIT_READ_CR2, "read_cr2" },
+    { SVM_EXIT_READ_CR3, "read_cr3" },
+    { SVM_EXIT_READ_CR4, "read_cr4" },
+    { SVM_EXIT_READ_CR8, "read_cr8" },
+
+    { SVM_EXIT_WRITE_CR0, "write_cr0" },
+    { SVM_EXIT_WRITE_CR2, "write_cr2" },
+    { SVM_EXIT_WRITE_CR3, "write_cr3" },
+    { SVM_EXIT_WRITE_CR4, "write_cr4" },
+    { SVM_EXIT_WRITE_CR8, "write_cr8" },
+
+    { SVM_EXIT_READ_DR0, "read_dr0" },
+    { SVM_EXIT_READ_DR1, "read_dr1" },
+    { SVM_EXIT_READ_DR2, "read_dr2" },
+    { SVM_EXIT_READ_DR3, "read_dr3" },
+    { SVM_EXIT_READ_DR4, "read_dr4" },
+    { SVM_EXIT_READ_DR5, "read_dr5" },
+    { SVM_EXIT_READ_DR6, "read_dr6" },
+    { SVM_EXIT_READ_DR7, "read_dr7" },
+
+    { SVM_EXIT_WRITE_DR0, "write_dr0" },
+    { SVM_EXIT_WRITE_DR1, "write_dr1" },
+    { SVM_EXIT_WRITE_DR2, "write_dr2" },
+    { SVM_EXIT_WRITE_DR3, "write_dr3" },
+    { SVM_EXIT_WRITE_DR4, "write_dr4" },
+    { SVM_EXIT_WRITE_DR5, "write_dr5" },
+    { SVM_EXIT_WRITE_DR6, "write_dr6" },
+    { SVM_EXIT_WRITE_DR7, "write_dr7" },
+
+    { SVM_EXIT_INTR, "interrupt" },
+    { SVM_EXIT_NMI, "nmi" },
+    { SVM_EXIT_SMI, "smi" },
+    { SVM_EXIT_INIT, "init" },
+    { SVM_EXIT_VINTR, "vintr" },
+
+    { SVM_EXIT_CPUID, "cpuid" },
+    { SVM_EXIT_HLT, "hlt" },
+    { SVM_EXIT_IOIO, "io" },
+    { SVM_EXIT_MSR, "msr" },
+    { SVM_EXIT_VMMCALL, "hypercall" },
+
+    { SVM_EXIT_INVPCID, "invpcid" },
+    { SVM_EXIT_BUS_LOCK, "buslock" },
+    { SVM_EXIT_IDLE_HLT, "idle-halt" },
+    { SVM_EXIT_NPF, "npf" },
+    { SVM_EXIT_AVIC_INCOMPLETE_IPI, "avic_incomplete_ipi" },
+    { SVM_EXIT_AVIC_UNACCELERATED_ACCESS, "avic_unaccelerated_access" },
+    { SVM_EXIT_VMGEXIT, "vmgexit" },
+
+    { SVM_VMGEXIT_MMIO_READ, "vmgexit_mmio_read" },
+    { SVM_VMGEXIT_MMIO_WRITE, "vmgexit_mmio_write" },
+    { SVM_VMGEXIT_NMI_COMPLETE, "vmgexit_nmi_complete" },
+    { SVM_VMGEXIT_AP_HLT_LOOP, "vmgexit_ap_hlt_loop" },
+    { SVM_VMGEXIT_AP_JUMP_TABLE, "vmgexit_ap_jump_table" },
+    { SVM_VMGEXIT_PSC, "vmgexit_page_state_change" },
+    { SVM_VMGEXIT_GUEST_REQUEST, "vmgexit_guest_request" },
+    { SVM_VMGEXIT_EXT_GUEST_REQUEST, "vmgexit_ext_guest_request" },
+    { SVM_VMGEXIT_AP_CREATION, "vmgexit_ap_creation" },
+    { SVM_VMGEXIT_HV_FEATURES, "vmgexit_hypervisor_feature" },
+
+    { SVM_EXIT_ERR, "invalid_guest_state" },
+};
     // From include/uapi/linux/kvm.h, KVM_EXIT_xxx
     struct NameMapping exitReasons_userspace[] = {
         {0, "UNKNOWN"},
@@ -183,9 +318,16 @@ const char *getName(int number, enum NameType type) {
     int count;
     switch (type) {
         case EXIT_NR:
+            // mappings = exitReasons;
+            // count = sizeof(exitReasons) / sizeof(exitReasons[0]);
+        if (current_vendor == KVM_VENDOR_AMD) {
+            mappings = svmExitReasons;
+            count = sizeof(svmExitReasons) / sizeof(svmExitReasons[0]);
+    } else {
             mappings = exitReasons;
             count = sizeof(exitReasons) / sizeof(exitReasons[0]);
-            break;
+    }
+    break;
         case EXIT_USERSPACE_NR:
             mappings = exitReasons_userspace;
             count = sizeof(exitReasons_userspace) /
@@ -1383,6 +1525,7 @@ int attach_probe(struct kvm_watcher_bpf *skel) {
     }
     return kvm_watcher_bpf__attach(skel);
 }
+
 int main(int argc, char **argv) {
     // 定义一个环形缓冲区
     struct ring_buffer *rb = NULL;
@@ -1392,6 +1535,7 @@ int main(int argc, char **argv) {
     err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
     if (err)
         return err;
+    current_vendor = detect_kvm_vendor();
     /*设置libbpf的错误和调试信息回调*/
     libbpf_set_print(libbpf_print_fn);
     /* Cleaner handling of Ctrl-C */
@@ -1442,15 +1586,22 @@ int main(int argc, char **argv) {
         print_logo();
 
     /*打印信息头*/
+
+    clear_screen();
+    fflush(stdout);
+    
     err = print_event_head(&env);
     if (err) {
         fprintf(stderr, "Please specify an option using %s.\n", OPTIONS_LIST);
         goto cleanup;
     }
     //实现刷屏操作
-    clear_screen();    
-    fflush(stdout);
-    print_description();
+    // clear_screen();    
+    // fflush(stdout);
+    // print_description();
+    if (env.execute_container_syscall) {
+        print_description();
+}
     //打印结果
     while (!exiting) {
         err = ring_buffer__poll(rb, RING_BUFFER_TIMEOUT_MS /* timeout, ms */);


### PR DESCRIPTION
第一 ：修复了之前kvm_watcher 存在的刷屏bug 
第二：之前的kvm_watcher 只适配了 vmx（intel cpu）版本，amd的cpu执行 kvm_watcher -e 的 vm_exit reason 不会显示，现在增加svm模式的 exit_reason 

<img width="1100" height="325" alt="image" src="https://github.com/user-attachments/assets/2b5cd121-c375-44bd-84d1-0d58d4e84b27" />
